### PR TITLE
Fix Sheets setup for tests and breed parsing

### DIFF
--- a/src/main/kotlin/co/qwex/chickenapi/ChickenApiApplication.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/ChickenApiApplication.kt
@@ -1,6 +1,6 @@
 package co.qwex.chickenapi
 
-import GoogleSheetsConfig
+import co.qwex.chickenapi.repository.db.GoogleSheetsConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Import

--- a/src/main/kotlin/co/qwex/chickenapi/repository/db/BreedRepository.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/repository/db/BreedRepository.kt
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Repository
 private val log = KotlinLogging.logger {}
 private const val SHEET_NAME = "breeds"
 private const val MIN_COLUMN = "A"
-private const val MAX_COLUMN = "G"
+private const val MAX_COLUMN = "I"
 
 @Repository
 class GoogleSheetBreedRepository(

--- a/src/main/kotlin/co/qwex/chickenapi/repository/db/GoogleSheetsConfig.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/repository/db/GoogleSheetsConfig.kt
@@ -1,8 +1,11 @@
+package co.qwex.chickenapi.repository.db
+
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.sheets.v4.Sheets
 import com.google.auth.http.HttpCredentialsAdapter
 import com.google.auth.oauth2.GoogleCredentials
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -13,6 +16,7 @@ class GoogleSheetsConfig {
     private val APPLICATION_NAME = "Chicken API"
 
     @Bean
+    @ConditionalOnMissingBean(Sheets::class)
     fun sheetsService(): Sheets {
         // 1. Pick up credentials from ADC (GOOGLE_APPLICATION_CREDENTIALS)
         val credentials = GoogleCredentials

--- a/src/test/kotlin/co/qwex/chickenapi/ChickenApiApplicationTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/ChickenApiApplicationTests.kt
@@ -4,25 +4,13 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.context.annotation.Bean
-import org.springframework.context.annotation.Primary
+import org.springframework.boot.test.mock.mockito.MockBean
 
 @SpringBootTest(classes = [ChickenApiApplication::class])
 class ChickenApiApplicationTests {
 
-    @TestConfiguration
-    internal class MockServiceConfig {
-        @Bean
-        @Primary // Ensures this mock bean takes precedence
-        fun mockStorage(): Sheets {
-            // Create a mock instance of the Storage service
-            return Mockito.mock(Sheets::class.java)
-        }
-    }
-
-    @Autowired
-    private lateinit var storage: Sheets // Autowire the mocked Storage bean
+    @MockBean
+    private lateinit var sheetsService: Sheets
 
     @Test
     fun contextLoads() {


### PR DESCRIPTION
## Summary
- ensure Google Sheets config is properly packaged and only created when no mock exists
- extend breed sheet range to include all fields
- simplify tests by mocking the Sheets bean with `@MockBean`
- update application imports

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684c2026418c8321a75ecffefd973ec8