### PR TITLE
Add breed detail page

### DIFF
--- a/src/main/kotlin/co/qwex/chickenapi/controller/BreedPageController.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/controller/BreedPageController.kt
@@ -1,0 +1,35 @@
+package co.qwex.chickenapi.controller
+
+import co.qwex.chickenapi.repository.BreedRepository
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.server.ResponseStatusException
+
+@Controller
+@RequestMapping("/breeds")
+class BreedPageController(
+    private val breedRepository: BreedRepository,
+) {
+
+    @GetMapping
+    fun breeds(model: Model): String {
+        val breeds = breedRepository.getAllBreeds()
+        model.addAttribute("breeds", breeds)
+        return "breeds"
+    }
+
+    @GetMapping("/{id}/view")
+    fun breedDetail(
+        @PathVariable id: Int,
+        model: Model,
+    ): String {
+        val breed = breedRepository.getBreedById(id)
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
+        model.addAttribute("breed", breed)
+        return "breed"
+    }
+}

--- a/src/main/resources/templates/breed.html
+++ b/src/main/resources/templates/breed.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: layout(~{::title}, ~{::section})">
+  <head>
+    <title th:text="${breed.name}">Breed Profile</title>
+  </head>
+  <section class="max-w-xl mx-auto bg-white shadow rounded-lg p-6">
+    <div class="flex flex-col items-center">
+      <img th:if="${breed.imageUrl}" th:src="${breed.imageUrl}" alt="breed image" class="w-48 h-48 object-cover rounded-full mb-4" />
+      <h1 class="text-3xl font-bold text-yellow-700 mb-2" th:text="${breed.name}"></h1>
+      <p class="text-gray-600 mb-4" th:text="${breed.description}"></p>
+    </div>
+    <dl class="grid grid-cols-2 gap-4">
+      <div>
+        <dt class="font-semibold">Origin</dt>
+        <dd th:text="${breed.origin}"></dd>
+      </div>
+      <div>
+        <dt class="font-semibold">Egg Color</dt>
+        <dd th:text="${breed.eggColor}"></dd>
+      </div>
+      <div>
+        <dt class="font-semibold">Egg Size</dt>
+        <dd th:text="${breed.eggSize}"></dd>
+      </div>
+      <div>
+        <dt class="font-semibold">Temperament</dt>
+        <dd th:text="${breed.temperament}"></dd>
+      </div>
+      <div>
+        <dt class="font-semibold">Eggs per year</dt>
+        <dd th:text="${breed.numEggs}"></dd>
+      </div>
+    </dl>
+    <div class="mt-6 text-center">
+      <a href="/breeds" class="text-blue-600 hover:underline">&larr; Back to breeds</a>
+    </div>
+  </section>
+</html>

--- a/src/main/resources/templates/breeds.html
+++ b/src/main/resources/templates/breeds.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: layout(~{::title}, ~{::section})">
+  <head>
+    <title>Chicken Breeds</title>
+  </head>
+  <section>
+    <h1 class="text-3xl font-bold mb-6 text-yellow-700 text-center">
+      Chicken Breeds
+    </h1>
+    <table class="min-w-full divide-y divide-gray-200 bg-white shadow rounded-lg">
+      <thead class="bg-gray-100">
+        <tr>
+          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Image</th>
+          <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
+          <th class="px-6 py-3"></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-gray-200" th:each="breed : ${breeds}">
+        <tr>
+          <td class="px-6 py-4" th:if="${breed.imageUrl}">
+            <img th:src="${breed.imageUrl}" alt="breed image" class="h-16 w-16 rounded object-cover" />
+          </td>
+          <td class="px-6 py-4" th:text="${breed.name}"></td>
+          <td class="px-6 py-4 text-right">
+            <a
+              class="text-blue-600 hover:underline"
+              th:href="@{'/breeds/' + ${breed.id} + '/view'}">View</a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</html>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,20 +1,22 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html xmlns:th="http://www.thymeleaf.org" th:replace="layout :: layout(~{::title}, ~{::section})">
   <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>🐔Chicken API </title>
-    <link rel="icon" href="/favicon_64.ico" type="image/x-icon" />
-    <script src="https://cdn.tailwindcss.com"></script>
+    <title>🐔Chicken API</title>
   </head>
-  <body class="bg-gray-50 flex items-center justify-center min-h-screen">
+  <section class="flex items-center justify-center min-h-screen">
     <div class="bg-white shadow-lg rounded-lg p-10 text-center">
       <h1 class="text-3xl font-bold mb-4 text-yellow-700">🐔Chicken API</h1>
       <p class="mb-6 text-gray-700">Welcome to the Chicken API!</p>
-      <a href="/swagger-ui/index.html"
-         class="inline-block px-6 py-3 bg-yellow-400 text-white font-semibold rounded hover:bg-yellow-500 transition">
-        View API Documentation
-      </a>
+      <div class="flex justify-center gap-4">
+        <a href="/breeds"
+           class="inline-block px-6 py-3 bg-yellow-400 text-white font-semibold rounded hover:bg-yellow-500 transition">
+          View Breeds
+        </a>
+        <a href="/swagger-ui/index.html"
+           class="inline-block px-6 py-3 bg-yellow-400 text-white font-semibold rounded hover:bg-yellow-500 transition">
+          View API Documentation
+        </a>
+      </div>
     </div>
-  </body>
+  </section>
 </html>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" th:fragment="layout(title, content)">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title th:replace="${title}">Chicken API</title>
+    <link rel="icon" href="/favicon_64.ico" type="image/x-icon" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+  </head>
+  <body class="bg-gray-50 min-h-screen">
+    <div class="container mx-auto p-6" th:replace="${content}"></div>
+  </body>
+</html>

--- a/src/test/kotlin/co/qwex/chickenapi/TestFixtures.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/TestFixtures.kt
@@ -1,0 +1,10 @@
+package co.qwex.chickenapi
+
+import co.qwex.chickenapi.model.Breed
+
+object TestFixtures {
+    val silkie = Breed(1, "Silkie", "China", "White", "Small", "Docile", "Fluffy", "img", 200)
+    val orpington = Breed(2, "Orpington", "UK", "Brown", "Large", "Friendly", "Big", "img2", 180)
+
+    fun breedList() = listOf(silkie, orpington)
+}

--- a/src/test/kotlin/co/qwex/chickenapi/controller/BreedPageControllerTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/controller/BreedPageControllerTests.kt
@@ -1,0 +1,44 @@
+import co.qwex.chickenapi.ChickenApiApplication
+import co.qwex.chickenapi.TestFixtures
+import co.qwex.chickenapi.repository.BreedRepository
+import com.google.api.services.sheets.v4.Sheets
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@SpringBootTest(classes = [ChickenApiApplication::class])
+@AutoConfigureMockMvc
+class BreedPageControllerTests {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockBean
+    lateinit var breedRepository: BreedRepository
+
+    @MockBean(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
+    lateinit var sheets: Sheets
+
+    @Test
+    fun `breeds page lists breeds`() {
+        Mockito.`when`(breedRepository.getAllBreeds()).thenReturn(TestFixtures.breedList())
+
+        mockMvc.get("/breeds")
+            .andExpect { status { isOk() } }
+            .andExpect { content { string(org.hamcrest.Matchers.containsString("Silkie")) } }
+            .andExpect { content { string(org.hamcrest.Matchers.containsString("Orpington")) } }
+    }
+
+    @Test
+    fun `breed detail page`() {
+        Mockito.`when`(breedRepository.getBreedById(1)).thenReturn(TestFixtures.silkie)
+
+        mockMvc.get("/breeds/1/view")
+            .andExpect { status { isOk() } }
+            .andExpect { content { string(org.hamcrest.Matchers.containsString("Fluffy")) } }
+    }
+}


### PR DESCRIPTION
## Summary
- convert breed fragment into a standalone page
- update breed list links to open the detail page
- introduce sample fixture objects for tests

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_684ca19a7cc48321bade391481c25f75