### PR TITLE
Add Supabase login and secure endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,9 +39,12 @@ dependencies {
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
     implementation("org.apache.commons:commons-text:1.10.0")
+    implementation("org.springframework.boot:spring-boot-starter-security")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }

--- a/src/main/kotlin/co/qwex/chickenapi/auth/ProtectedController.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/auth/ProtectedController.kt
@@ -1,0 +1,19 @@
+package co.qwex.chickenapi.auth
+
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/protected")
+class ProtectedController {
+    @GetMapping
+    fun user(@AuthenticationPrincipal jwt: Jwt): Map<String, Any?> {
+        return mapOf(
+            "user_id" to jwt.subject,
+            "email" to jwt.claims["email"]
+        )
+    }
+}

--- a/src/main/kotlin/co/qwex/chickenapi/security/SecurityConfig.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/security/SecurityConfig.kt
@@ -1,0 +1,23 @@
+package co.qwex.chickenapi.security
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+class SecurityConfig {
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .authorizeHttpRequests { auth ->
+                auth
+                    .requestMatchers("/api/v1/protected/**").authenticated()
+                    .requestMatchers("/", "/breeds", "/breeds/*/view", "/swagger-ui/**", "/v3/api-docs/**", "/favicon_64.ico", "/api/**").permitAll()
+                    .anyRequest().permitAll()
+            }
+            .oauth2ResourceServer { it.jwt() }
+            .csrf { it.disable() }
+        return http.build()
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,10 @@
 spring.application.name=chicken-api
 
+# Google Sheets configuration
 google.sheets.db.spreadsheetId=1fZBTykjv03MY8p0U8pbIsItKqOeJuNHm_zCWDUj_DiA
 google.sheets.breeds.range=breeds!A1:G
+
+# Supabase configuration
+supabase.url=https://your-project.supabase.co
+supabase.anon-key=YOUR_ANON_KEY
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${supabase.url}/auth/v1

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -10,7 +10,7 @@
     <div class="bg-white shadow-lg rounded-lg p-10 text-center">
       <h1 class="text-3xl font-bold mb-4 text-yellow-700">🐔Chicken API</h1>
       <p class="mb-6 text-gray-700">Welcome to the Chicken API!</p>
-      <div class="flex justify-center gap-4">
+      <div class="flex justify-center gap-4" id="buttons">
         <a href="/breeds"
            class="inline-block px-6 py-3 bg-yellow-400 text-white font-semibold rounded hover:bg-yellow-500 transition">
           View Breeds
@@ -19,7 +19,21 @@
            class="inline-block px-6 py-3 bg-yellow-400 text-white font-semibold rounded hover:bg-yellow-500 transition">
           View API Documentation
         </a>
+        <button id="login" class="px-6 py-3 bg-yellow-400 text-white font-semibold rounded hover:bg-yellow-500 transition">
+          Login
+        </button>
       </div>
     </div>
   </section>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script>
+    const supabase = window.supabase.createClient(
+      document.querySelector('meta[name="supabase-url"]').content,
+      document.querySelector('meta[name="supabase-key"]').content
+    );
+    document.getElementById('login').addEventListener('click', async () => {
+      const { data, error } = await supabase.auth.signInWithOAuth({ provider: 'github' });
+      if (error) { console.error(error); }
+    });
+  </script>
 </html>

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title th:replace="${title}">Chicken API</title>
     <link rel="icon" href="/favicon_64.ico" type="image/x-icon" />
+    <meta name="supabase-url" th:content="${@environment.getProperty('supabase.url')}" />
+    <meta name="supabase-key" th:content="${@environment.getProperty('supabase.anon-key')}" />
     <script src="https://cdn.tailwindcss.com"></script>
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
   </head>

--- a/src/test/kotlin/co/qwex/chickenapi/auth/ProtectedControllerTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/auth/ProtectedControllerTests.kt
@@ -1,0 +1,40 @@
+package co.qwex.chickenapi.auth
+
+import co.qwex.chickenapi.ChickenApiApplication
+import com.google.api.services.sheets.v4.Sheets
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.request
+
+@SpringBootTest(classes = [ChickenApiApplication::class])
+@AutoConfigureMockMvc
+class ProtectedControllerTests {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockBean(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
+    lateinit var sheets: Sheets
+
+    @Test
+    fun `requires authentication`() {
+        mockMvc.get("/api/v1/protected").andExpect { status { isUnauthorized() } }
+    }
+
+    @Test
+    fun `returns user info with jwt`() {
+        mockMvc.get("/api/v1/protected") {
+            with(SecurityMockMvcRequestPostProcessors.jwt().jwt {
+                it.claim("email", "test@example.com")
+                it.subject("123")
+            })
+        }
+            .andExpect { status { isOk() } }
+            .andExpect { jsonPath("$.email") { value("test@example.com") } }
+    }
+}


### PR DESCRIPTION
## Summary
- add Spring Security configuration
- create protected controller using JWT auth
- expose supabase settings via layout and login script
- add tests for protected route

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684f3d408a9883219583530e5699a613