### PR TITLE
Fix deprecated MockBean usages

### DIFF
--- a/src/test/kotlin/co/qwex/chickenapi/ChickenApiApplicationTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/ChickenApiApplicationTests.kt
@@ -2,12 +2,12 @@ import co.qwex.chickenapi.ChickenApiApplication
 import com.google.api.services.sheets.v4.Sheets
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 
 @SpringBootTest(classes = [ChickenApiApplication::class])
 class ChickenApiApplicationTests {
 
-    @MockBean
+    @MockitoBean
     private lateinit var sheetsService: Sheets
 
     @Test

--- a/src/test/kotlin/co/qwex/chickenapi/controller/BreedControllerTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/controller/BreedControllerTests.kt
@@ -7,7 +7,7 @@ import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
@@ -17,7 +17,7 @@ class BreedControllerTests {
     @Autowired
     lateinit var mockMvc: MockMvc
 
-    @MockBean(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
+    @MockitoBean(answers = org.mockito.Answers.RETURNS_DEEP_STUBS)
     lateinit var sheets: Sheets
 
     private fun mockBreedListResponse(values: List<List<Any>>) {

--- a/src/test/kotlin/co/qwex/chickenapi/controller/BreedPageControllerTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/controller/BreedPageControllerTests.kt
@@ -7,7 +7,7 @@ import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
@@ -17,10 +17,10 @@ class BreedPageControllerTests {
     @Autowired
     lateinit var mockMvc: MockMvc
 
-    @MockBean
+    @MockitoBean
     lateinit var breedRepository: BreedRepository
 
-    @MockBean(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
+    @MockitoBean(answers = org.mockito.Answers.RETURNS_DEEP_STUBS)
     lateinit var sheets: Sheets
 
     @Test

--- a/src/test/kotlin/co/qwex/chickenapi/controller/ChickenControllerTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/controller/ChickenControllerTests.kt
@@ -7,7 +7,7 @@ import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 
@@ -17,7 +17,7 @@ class ChickenControllerTests {
     @Autowired
     lateinit var mockMvc: MockMvc
 
-    @MockBean(answer = org.mockito.Answers.RETURNS_DEEP_STUBS)
+    @MockitoBean(answers = org.mockito.Answers.RETURNS_DEEP_STUBS)
     lateinit var sheets: Sheets
 
     private fun mockChickenById(id: Int, values: List<List<Any>>) {


### PR DESCRIPTION
## Summary
- replace deprecated `MockBean` annotations with `MockitoBean`

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684f83a87e3483218219f2c1045d566c