### PR TITLE
Add Supabase OAuth example endpoint

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,10 +39,13 @@ dependencies {
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
     implementation("org.apache.commons:commons-text:1.10.0")
+    implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+    implementation("org.springframework.boot:spring-boot-starter-security")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
+    testImplementation("org.springframework.security:spring-security-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/src/main/kotlin/co/qwex/chickenapi/config/SecurityConfig.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/config/SecurityConfig.kt
@@ -1,0 +1,34 @@
+package co.qwex.chickenapi.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+class SecurityConfig {
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .authorizeHttpRequests { auth ->
+                auth
+                    .requestMatchers(
+                        "/",
+                        "/breeds/**",
+                        "/api/v1/breeds/**",
+                        "/api/v1/chickens/**",
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**",
+                        "/static/**",
+                        "/favicon.ico",
+                        "/login"
+                    ).permitAll()
+                    .anyRequest().authenticated()
+            }
+            .oauth2ResourceServer { oauth2 ->
+                oauth2.jwt {}
+            }
+        return http.build()
+    }
+}

--- a/src/main/kotlin/co/qwex/chickenapi/controller/auth/AuthenticatedController.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/controller/auth/AuthenticatedController.kt
@@ -1,0 +1,12 @@
+package co.qwex.chickenapi.controller.auth
+
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth")
+class AuthenticatedController {
+    @GetMapping("/hello")
+    fun hello(): String = "hello authenticated world"
+}

--- a/src/main/kotlin/co/qwex/chickenapi/controller/auth/LoginController.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/controller/auth/LoginController.kt
@@ -1,0 +1,21 @@
+package co.qwex.chickenapi.controller.auth
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+
+@Controller
+class LoginController(
+    @Value("\${supabase.url:https://your-project.supabase.co}")
+    private val supabaseUrl: String,
+    @Value("\${supabase.anon-key:YOUR_ANON_KEY}")
+    private val anonKey: String,
+) {
+    @GetMapping("/login")
+    fun login(model: Model): String {
+        model.addAttribute("supabaseUrl", supabaseUrl)
+        model.addAttribute("supabaseAnonKey", anonKey)
+        return "login"
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,9 @@ spring.application.name=chicken-api
 
 google.sheets.db.spreadsheetId=1fZBTykjv03MY8p0U8pbIsItKqOeJuNHm_zCWDUj_DiA
 google.sheets.breeds.range=breeds!A1:G
+
+# Supabase configuration
+supabase.url=https://your-project.supabase.co
+supabase.anon-key=YOUR_ANON_KEY
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=${supabase.url}/auth/v1/keys
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${supabase.url}/auth/v1

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -19,6 +19,10 @@
            class="inline-block px-6 py-3 bg-yellow-400 text-white font-semibold rounded hover:bg-yellow-500 transition">
           View API Documentation
         </a>
+        <a href="/login"
+           class="inline-block px-6 py-3 bg-yellow-400 text-white font-semibold rounded hover:bg-yellow-500 transition">
+          Login
+        </a>
       </div>
     </div>
   </section>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" th:replace="~{layout :: layout(~{::title}, ~{::section})}">
+  <head>
+    <title>Login</title>
+    <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+    <script th:inline="javascript">
+      const supabase = supabase.createClient("[[${supabaseUrl}]]", "[[${supabaseAnonKey}]]")
+      function signIn(provider) {
+        supabase.auth.signInWithOAuth({ provider })
+      }
+    </script>
+  </head>
+  <section class="flex items-center justify-center min-h-screen">
+    <div class="bg-white shadow-lg rounded-lg p-10 text-center">
+      <h1 class="text-2xl font-bold mb-4">Sign In</h1>
+      <div class="flex flex-col gap-4">
+        <button class="px-6 py-2 bg-yellow-400 text-white rounded" onclick="signIn('google')">Google</button>
+        <button class="px-6 py-2 bg-yellow-400 text-white rounded" onclick="signIn('apple')">Apple</button>
+        <button class="px-6 py-2 bg-yellow-400 text-white rounded" onclick="signIn('facebook')">Facebook</button>
+      </div>
+    </div>
+  </section>
+</html>

--- a/src/test/kotlin/co/qwex/chickenapi/controller/AuthenticatedControllerTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/controller/AuthenticatedControllerTests.kt
@@ -1,0 +1,35 @@
+import co.qwex.chickenapi.ChickenApiApplication
+import com.google.api.services.sheets.v4.Sheets
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+
+@SpringBootTest(classes = [ChickenApiApplication::class])
+@AutoConfigureMockMvc
+class AuthenticatedControllerTests {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockitoBean(answers = org.mockito.Answers.RETURNS_DEEP_STUBS)
+    lateinit var sheets: Sheets
+
+    @Test
+    fun `requires authentication`() {
+        mockMvc.get("/api/v1/auth/hello")
+            .andExpect { status { isUnauthorized() } }
+    }
+
+    @Test
+    fun `authenticated request`() {
+        mockMvc.get("/api/v1/auth/hello") {
+            with(jwt())
+        }
+            .andExpect { status { isOk() } }
+            .andExpect { content { string("hello authenticated world") } }
+    }
+}


### PR DESCRIPTION
## Summary
- configure Spring Security resource server for JWT authentication
- add login page with Supabase OAuth helpers
- expose `/api/v1/auth/hello` endpoint secured by JWT
- create `SecurityConfig` to allow anonymous access to existing endpoints
- add tests for authenticated endpoint

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685166008c1c8321adacb8898a908348