### PR TITLE
Add HATEOAS support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-hateoas")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/src/main/kotlin/co/qwex/chickenapi/controller/BreedController.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/controller/BreedController.kt
@@ -2,6 +2,7 @@ package co.qwex.chickenapi.controller
 
 import mu.KotlinLogging
 import org.apache.commons.text.similarity.LevenshteinDistance
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -19,10 +20,10 @@ class BreedController(
     @GetMapping()
     fun getAllBreeds(
         @RequestParam(required = false) name: String?,
-    ): List<Breed> {
+    ): List<BreedResponse> {
         log.info { "Fetching all breeds" }
         val breeds = breedRepository.getAllBreeds().map { breed ->
-            Breed(
+            BreedResponse(
                 name = breed.name,
                 origin = breed.origin,
                 eggColor = breed.eggColor,
@@ -31,7 +32,9 @@ class BreedController(
                 description = breed.description,
                 imageUrl = breed.imageUrl,
                 eggNumber = 0,
-            )
+            ).apply {
+                add(linkTo(BreedController::class.java).slash(breed.id).withSelfRel())
+            }
         }
         log.info { "Fetched ${breeds.size} breeds" }
 
@@ -46,13 +49,13 @@ class BreedController(
     @GetMapping("{id}")
     fun getBreedById(
         @PathVariable id: Int,
-    ): Breed? {
+    ): BreedResponse {
         log.info { "Fetching breed with ID $id" }
         val breed = breedRepository.getBreedById(id)
         log.info { "Fetched breed with ID $id: $breed" }
         breed ?: throw IllegalArgumentException("Breed with ID $id not found")
         return breed.let {
-            Breed(
+            BreedResponse(
                 name = it.name,
                 origin = it.origin,
                 eggColor = it.eggColor,
@@ -61,12 +64,14 @@ class BreedController(
                 temperament = it.temperament,
                 description = it.description,
                 imageUrl = it.imageUrl,
-            )
+            ).apply {
+                add(linkTo(BreedController::class.java).slash(id).withSelfRel())
+            }
         }
     }
 }
 
-data class Breed(
+data class BreedResponse(
     val name: String,
     val origin: String?,
     val eggColor: String?,
@@ -75,4 +80,4 @@ data class Breed(
     val temperament: String?,
     val description: String?,
     val imageUrl: String?,
-)
+) : org.springframework.hateoas.RepresentationModel<BreedResponse>()

--- a/src/main/kotlin/co/qwex/chickenapi/controller/ChickenController.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/controller/ChickenController.kt
@@ -1,6 +1,8 @@
 package co.qwex.chickenapi.controller
 
 import co.qwex.chickenapi.repository.ChickenRepository
+import co.qwex.chickenapi.controller.BreedController
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -12,23 +14,26 @@ class ChickenController(val repository: ChickenRepository) {
     @GetMapping("{id}")
     fun getChickenById(
         @PathVariable id: Int,
-    ): Chicken {
+    ): ChickenResponse {
         val chickenById = repository.getChickenById(id)
         chickenById ?: throw IllegalArgumentException("Chicken with ID $id not found")
         return chickenById.let {
-            Chicken(
+            ChickenResponse(
                 id = it.id,
                 name = it.name,
                 breedId = it.breedId,
                 imageUrl = it.imageUrl,
-            )
+            ).apply {
+                add(linkTo(ChickenController::class.java).slash(id).withSelfRel())
+                add(linkTo(BreedController::class.java).slash(it.breedId).withRel("breed"))
+            }
         }
     }
 }
 
-data class Chicken(
+data class ChickenResponse(
     val id: Int,
     val name: String,
     val breedId: Int,
     val imageUrl: String,
-)
+) : org.springframework.hateoas.RepresentationModel<ChickenResponse>()

--- a/src/test/kotlin/co/qwex/chickenapi/controller/BreedControllerTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/controller/BreedControllerTests.kt
@@ -50,6 +50,9 @@ class BreedControllerTests {
             .andExpect { jsonPath("$.length()") { value(2) } }
             .andExpect { jsonPath("$[0].name") { value("Silkie") } }
             .andExpect { jsonPath("$[1].name") { value("Orpington") } }
+            .andExpect { jsonPath("$[0].links[0].href") { value("http://localhost/api/v1/breeds/1") } }
+            .andExpect { jsonPath("$[0].links[0].rel") { value("self") } }
+            .andExpect { jsonPath("$[1].links[0].href") { value("http://localhost/api/v1/breeds/2") } }
     }
 
     @Test
@@ -60,6 +63,7 @@ class BreedControllerTests {
         mockMvc.get("/api/v1/breeds/$id")
             .andExpect { status { isOk() } }
             .andExpect { jsonPath("$.name") { value("Silkie") } }
+            .andExpect { jsonPath("$._links.self.href") { value("http://localhost/api/v1/breeds/$id") } }
     }
 
     @Test
@@ -76,5 +80,7 @@ class BreedControllerTests {
             .andExpect { status { isOk() } }
             .andExpect { jsonPath("$.length()") { value(1) } }
             .andExpect { jsonPath("$[0].name") { value("Orpington") } }
+            .andExpect { jsonPath("$[0].links[0].href") { value("http://localhost/api/v1/breeds/2") } }
+            .andExpect { jsonPath("$[0].links[0].rel") { value("self") } }
     }
 }

--- a/src/test/kotlin/co/qwex/chickenapi/controller/ChickenControllerTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/controller/ChickenControllerTests.kt
@@ -37,5 +37,7 @@ class ChickenControllerTests {
             .andExpect { status { isOk() } }
             .andExpect { jsonPath("$.name") { value("Clucky") } }
             .andExpect { jsonPath("$.breedId") { value(2) } }
+            .andExpect { jsonPath("$._links.self.href") { value("http://localhost/api/v1/chickens/$id") } }
+            .andExpect { jsonPath("$._links.breed.href") { value("http://localhost/api/v1/breeds/2") } }
     }
 }


### PR DESCRIPTION
## Summary
- add spring-hateoas dependency
- provide hypermedia links for Breed and Chicken API responses
- adjust tests for new links

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685d1b22db748321ad0959d06a994a18