### PR TITLE
Add Bucket4j rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@
 - [x] Add chicken endpoint so you can upload your own chicken
 - [ ] Add google form to submit chicken
 - [ ] Add a way to vote on chickens
+### Rate limit configuration
+Bucket4j limits are defined in `application.yml`. Adjust the `capacity` and `time` fields
+under `bucket4j.filters` to tweak global or per-IP limits.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-hateoas")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("com.giffing.bucket4j.spring.boot.starter:bucket4j-spring-boot-starter:0.12.10")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.google.api-client:google-api-client:2.4.1")
     implementation("com.google.apis:google-api-services-sheets:v4-rev20230815-2.0.0")

--- a/src/main/kotlin/co/qwex/chickenapi/config/RateLimitExceptionHandler.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/config/RateLimitExceptionHandler.kt
@@ -1,0 +1,15 @@
+package co.qwex.chickenapi.config
+
+import com.giffing.bucket4j.spring.boot.starter.exception.Bucket4jGeneralException
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class RateLimitExceptionHandler {
+    @ExceptionHandler(Bucket4jGeneralException::class)
+    @ResponseStatus(HttpStatus.TOO_MANY_REQUESTS)
+    fun handleRateLimit(): Map<String, String> =
+        mapOf("message" to "Too many requests")
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,0 @@
-spring.application.name=chicken-api
-
-google.sheets.db.spreadsheetId=1fZBTykjv03MY8p0U8pbIsItKqOeJuNHm_zCWDUj_DiA
-google.sheets.breeds.range=breeds!A1:G

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,34 @@
+spring:
+  application:
+    name: chicken-api
+
+google:
+  sheets:
+    db:
+      spreadsheetId: 1fZBTykjv03MY8p0U8pbIsItKqOeJuNHm_zCWDUj_DiA
+    breeds:
+      range: breeds!A1:G
+
+bucket4j:
+  enabled: true
+  filters:
+    - cache-name: in-memory-buckets
+      url: /api/**
+      rate-limits:
+        - bandwidths:
+            - capacity: 10
+              time: 1
+              unit: seconds
+      metrics:
+        enabled: true
+    - cache-name: in-memory-buckets
+      url: /api/**
+      http-methods: [POST]
+      cache-key: "#{request.remoteAddr}"
+      rate-limits:
+        - bandwidths:
+            - capacity: 1
+              time: 1
+              unit: minutes
+      metrics:
+        enabled: true

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,12 @@
+bucket4j:
+  enabled: false
+spring:
+  application:
+    name: chicken-api
+
+google:
+  sheets:
+    db:
+      spreadsheetId: 1fZBTykjv03MY8p0U8pbIsItKqOeJuNHm_zCWDUj_DiA
+    breeds:
+      range: breeds!A1:G


### PR DESCRIPTION
## Summary
- add Bucket4j Spring Boot starter
- configure rate-limit rules in `application.yml`
- create fallback handler returning HTTP 429
- disable Bucket4j in tests and document how to tweak limits

## Testing
- `./gradlew spotlessApply --no-daemon`
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_687ad29aee2883218d114f9fce4c3dd2