### PR TITLE
Add POST-specific rate limit

### DIFF
--- a/RATE_LIMITING.md
+++ b/RATE_LIMITING.md
@@ -153,6 +153,18 @@ bucket4j.filters[1].rate-limits[0].bandwidths[0].unit=hours
 bucket4j.filters[1].rate-limits[0].cache-key=@httpServletRequest.remoteAddr
 ```
 
+For example, the application now includes a second filter that targets **POST**
+requests globally:
+
+```properties
+bucket4j.filters[1].cache-name=buckets
+bucket4j.filters[1].url=.*
+bucket4j.filters[1].http-method=POST
+bucket4j.filters[1].rate-limits[0].bandwidths[0].capacity=50
+bucket4j.filters[1].rate-limits[0].bandwidths[0].time=1
+bucket4j.filters[1].rate-limits[0].bandwidths[0].unit=minutes
+```
+
 ### 4.5. Troubleshooting
 
 -   **"No Bucket4j cache configuration found"**: Ensure `spring.cache.type=jcache` is set, `bucket4j.cache-to-use=jcache` is present, and the necessary Caffeine and JCache dependencies are in `build.gradle.kts`. Also, confirm `@EnableCaching` is on your main application class.

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,11 @@ bucket4j.filters[0].url=.*
 bucket4j.filters[0].rate-limits[0].bandwidths[0].capacity=1000
 bucket4j.filters[0].rate-limits[0].bandwidths[0].time=1
 bucket4j.filters[0].rate-limits[0].bandwidths[0].unit=minutes
+
+# Specific rate limit for POST requests
+bucket4j.filters[1].cache-name=buckets
+bucket4j.filters[1].url=.*
+bucket4j.filters[1].http-method=POST
+bucket4j.filters[1].rate-limits[0].bandwidths[0].capacity=50
+bucket4j.filters[1].rate-limits[0].bandwidths[0].time=1
+bucket4j.filters[1].rate-limits[0].bandwidths[0].unit=minutes


### PR DESCRIPTION
## Summary
- add POST-specific rate limit configuration
- document POST filter in rate limiting guide

## Testing
- `./gradlew spotlessApply --no-daemon`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_687ee0cf922c8321b551234237a51cd9