### PR TITLE
Fix breed API egg count mapping

### DIFF
--- a/src/main/kotlin/co/qwex/chickenapi/controller/BreedController.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/controller/BreedController.kt
@@ -40,7 +40,7 @@ class BreedController(
                     temperament = breed.temperament,
                     description = breed.description,
                     imageUrl = breed.imageUrl,
-                    eggNumber = 0,
+                    eggNumber = breed.numEggs,
                 ),
             )
             model.add(linkTo(BreedController::class.java).slash(breed.id).withSelfRel())
@@ -72,7 +72,7 @@ class BreedController(
                     origin = it.origin,
                     eggColor = it.eggColor,
                     eggSize = it.eggSize,
-                    eggNumber = 0,
+                    eggNumber = it.numEggs,
                     temperament = it.temperament,
                     description = it.description,
                     imageUrl = it.imageUrl,

--- a/src/test/kotlin/co/qwex/chickenapi/controller/BreedControllerTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/controller/BreedControllerTests.kt
@@ -56,6 +56,8 @@ class BreedControllerTests {
             .andExpect { jsonPath("$.length()") { value(2) } }
             .andExpect { jsonPath("$[0].name") { value("Silkie") } }
             .andExpect { jsonPath("$[1].name") { value("Orpington") } }
+            .andExpect { jsonPath("$[0].eggNumber") { value(200) } }
+            .andExpect { jsonPath("$[1].eggNumber") { value(180) } }
             .andExpect { jsonPath("$[0].links[0].href") { value("http://localhost/api/v1/breeds/1") } }
             .andExpect { jsonPath("$[0].links[0].rel") { value("self") } }
             .andExpect { jsonPath("$[1].links[0].href") { value("http://localhost/api/v1/breeds/2") } }
@@ -69,6 +71,7 @@ class BreedControllerTests {
         mockMvc.get("/api/v1/breeds/$id")
             .andExpect { status { isOk() } }
             .andExpect { jsonPath("$.name") { value("Silkie") } }
+            .andExpect { jsonPath("$.eggNumber") { value(200) } }
             .andExpect { jsonPath("$._links.self.href") { value("http://localhost/api/v1/breeds/$id") } }
     }
 
@@ -86,6 +89,7 @@ class BreedControllerTests {
             .andExpect { status { isOk() } }
             .andExpect { jsonPath("$.length()") { value(1) } }
             .andExpect { jsonPath("$[0].name") { value("Orpington") } }
+            .andExpect { jsonPath("$[0].eggNumber") { value(180) } }
             .andExpect { jsonPath("$[0].links[0].href") { value("http://localhost/api/v1/breeds/2") } }
             .andExpect { jsonPath("$[0].links[0].rel") { value("self") } }
     }


### PR DESCRIPTION
## Summary
- Propagate egg counts from repository to Breed API responses
- Add tests to ensure egg numbers are returned

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6891fe1a2ac4832186a16f0b945c4c55