### PR TITLE
Add about page and refine landing page

### DIFF
--- a/src/main/kotlin/co/qwex/chickenapi/controller/LandingController.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/controller/LandingController.kt
@@ -9,4 +9,9 @@ class LandingController {
     fun landing(): String {
         return "index"
     }
+
+    @GetMapping("/about")
+    fun about(): String {
+        return "about"
+    }
 }

--- a/src/main/resources/templates/about.html
+++ b/src/main/resources/templates/about.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html
+  xmlns:th="http://www.thymeleaf.org"
+  th:replace="~{layout :: layout(~{::title}, ~{::section})}"
+>
+  <head>
+    <title>About / Contribute</title>
+  </head>
+  <section class="max-w-2xl mx-auto">
+    <h1 class="text-3xl font-bold mb-6 text-yellow-700 text-center">About / Contribute</h1>
+    <p class="mb-4 text-gray-700">
+      TODO: Add information about who you are and the purpose of the project.
+    </p>
+    <h2 class="text-2xl font-semibold mb-2">How to Submit Data</h2>
+    <p class="mb-4 text-gray-700">
+      TODO: Describe the process for submitting new chicken or breed data.
+    </p>
+    <div class="mt-6 text-center">
+      <script
+        type="text/javascript"
+        src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js"
+        data-name="bmc-button"
+        data-slug="qwex"
+        data-color="#FF5F5F"
+        data-emoji="🐔"
+        data-font="Arial"
+        data-text="Support the Flock"
+        data-outline-color="#000000"
+        data-font-color="#ffffff"
+        data-coffee-color="#FFDD00"
+      ></script>
+    </div>
+  </section>
+</html>

--- a/src/main/resources/templates/about.html
+++ b/src/main/resources/templates/about.html
@@ -7,13 +7,21 @@
     <title>About / Contribute</title>
   </head>
   <section class="max-w-2xl mx-auto">
-    <h1 class="text-3xl font-bold mb-6 text-yellow-700 text-center">About / Contribute</h1>
+    <h1 class="text-3xl font-bold mb-6 text-yellow-700 text-center">
+      About / Contribute
+    </h1>
     <p class="mb-4 text-gray-700">
-      TODO: Add information about who you are and the purpose of the project.
+      Howdy, I'm Ben, welcome to chicken-api 🐔🌐 I wanted to make a fun project
+      to host everything chicken. I want this to grow into the de facto standard
+      for chicken-related data. If you have a chance please add a breed or your
+      own chicken! Contributions are welcome to the code too, feel free to
+      submit a pull request!
     </p>
     <h2 class="text-2xl font-semibold mb-2">How to Submit Data</h2>
     <p class="mb-4 text-gray-700">
-      TODO: Describe the process for submitting new chicken or breed data.
+      To add a new chicken breed, please make a post request to /api/v1/breeds.
+      We will review and add to the production database. To add new features or
+      requests, please open an issue on our GitHub repository.
     </p>
     <div class="mt-6 text-center">
       <script

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -4,16 +4,16 @@
   th:replace="~{layout :: layout(~{::title}, ~{::section})}"
 >
   <head>
-    <title>🐔Chicken API</title>
+    <title>🐔Chicken API🌐</title>
   </head>
   <section class="flex items-center justify-center min-h-screen">
     <div class="bg-white shadow-lg rounded-lg p-10 text-center">
-      <h1 class="text-3xl font-bold mb-4 text-yellow-700">🐔Chicken API</h1>
+      <h1 class="text-3xl font-bold mb-4 text-yellow-700">🐔Chicken API🌐</h1>
       <p class="mb-6 text-gray-700">
         Open-source chicken breed data, ready for your apps.
       </p>
       <pre class="bg-gray-100 p-4 rounded text-left mb-6">
-<code>curl https://chickenapi.com/api/v1/breeds</code>
+<code>curl -X GET "https://chickenapi.com/api/v1/breeds/"</code>
       </pre>
       <div class="flex flex-wrap justify-center gap-4">
         <a

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -9,8 +9,13 @@
   <section class="flex items-center justify-center min-h-screen">
     <div class="bg-white shadow-lg rounded-lg p-10 text-center">
       <h1 class="text-3xl font-bold mb-4 text-yellow-700">🐔Chicken API</h1>
-      <p class="mb-6 text-gray-700">Welcome to the Chicken API!</p>
-      <div class="flex justify-center gap-4">
+      <p class="mb-6 text-gray-700">
+        Open-source chicken breed data, ready for your apps.
+      </p>
+      <pre class="bg-gray-100 p-4 rounded text-left mb-6">
+<code>curl https://chickenapi.com/api/v1/breeds</code>
+      </pre>
+      <div class="flex flex-wrap justify-center gap-4">
         <a
           href="/breeds"
           class="inline-block px-6 py-3 bg-yellow-400 text-white font-semibold rounded hover:bg-yellow-500 transition"
@@ -21,23 +26,22 @@
           href="/swagger-ui/index.html"
           class="inline-block px-6 py-3 bg-yellow-400 text-white font-semibold rounded hover:bg-yellow-500 transition"
         >
-          View API Documentation
+          API Docs
         </a>
-      </div>
-      <div class="mt-6">
-        <script
-          type="text/javascript"
-          src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js"
-          data-name="bmc-button"
-          data-slug="qwex"
-          data-color="#FF5F5F"
-          data-emoji="🐔"
-          data-font="Arial"
-          data-text="Support the Flock"
-          data-outline-color="#000000"
-          data-font-color="#ffffff"
-          data-coffee-color="#FFDD00"
-        ></script>
+        <a
+          href="https://github.com/qWeX23/chicken-api"
+          class="inline-block px-6 py-3 bg-yellow-400 text-white font-semibold rounded hover:bg-yellow-500 transition"
+          target="_blank"
+          rel="noopener"
+        >
+          GitHub
+        </a>
+        <a
+          href="/about"
+          class="inline-block px-6 py-3 bg-yellow-400 text-white font-semibold rounded hover:bg-yellow-500 transition"
+        >
+          About / Contribute
+        </a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- add placeholder About/Contribute page with Buy Me A Coffee button
- refresh landing page with value prop, curl example, and links to docs & GitHub
- expose new `/about` endpoint

## Testing
- `./gradlew spotlessApply`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_6891fe71a994832185d9e331547b86dc