### PR TITLE
feat: allow layout to accept meta fragments

### DIFF
--- a/src/main/resources/templates/breed.html
+++ b/src/main/resources/templates/breed.html
@@ -1,10 +1,21 @@
 <!DOCTYPE html>
 <html
   xmlns:th="http://www.thymeleaf.org"
-  th:replace="~{layout :: layout(~{::title}, ~{::section})}"
+  th:replace="~{layout :: layout(~{::title}, ~{::section}, ~{::meta})}"
 >
   <head>
     <title th:text="${breed.name}">Breed Profile</title>
+    <th:block th:fragment="meta">
+      <meta name="description" th:content="${breed.description}" />
+      <meta property="og:title" th:content="${breed.name}" />
+      <meta property="og:description" th:content="${breed.description}" />
+      <meta property="og:image" th:if="${breed.imageUrl}" th:content="${breed.imageUrl}" />
+      <meta
+        property="og:url"
+        th:content="@{'/breeds/' + ${breed.id} + '/view'}"
+      />
+      <meta property="og:type" content="website" />
+    </th:block>
   </head>
   <section class="max-w-xl mx-auto bg-white shadow rounded-lg p-6">
     <div class="flex flex-col items-center">

--- a/src/main/resources/templates/breeds.html
+++ b/src/main/resources/templates/breeds.html
@@ -1,10 +1,17 @@
 <!DOCTYPE html>
 <html
   xmlns:th="http://www.thymeleaf.org"
-  th:replace="~{layout :: layout(~{::title}, ~{::section})}"
+  th:replace="~{layout :: layout(~{::title}, ~{::section}, ~{::meta})}"
 >
   <head>
     <title>Chicken Breeds</title>
+    <th:block th:fragment="meta">
+      <meta name="description" content="Browse chicken breeds in the Chicken API." />
+      <meta property="og:title" content="Chicken Breeds" />
+      <meta property="og:description" content="Browse chicken breeds in the Chicken API." />
+      <meta property="og:url" th:content="@{/breeds}" />
+      <meta property="og:type" content="website" />
+    </th:block>
   </head>
   <section>
     <h1 class="text-3xl font-bold mb-6 text-yellow-700 text-center">

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,10 +1,13 @@
 <!DOCTYPE html>
 <html
   xmlns:th="http://www.thymeleaf.org"
-  th:replace="~{layout :: layout(~{::title}, ~{::section})}"
+  th:replace="~{layout :: layout(~{::title}, ~{::section}, ~{::meta})}"
 >
   <head>
     <title>🐔Chicken API</title>
+    <th:block th:fragment="meta">
+      <meta name="description" content="Welcome to the Chicken API home page." />
+    </th:block>
   </head>
   <section class="flex items-center justify-center min-h-screen">
     <div class="bg-white shadow-lg rounded-lg p-10 text-center">

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org" th:fragment="layout(title, content)">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" th:fragment="layout(title, content, meta)">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <th:block th:replace="${meta}" />
     <title th:replace="${title}">Chicken API</title>
     <link rel="icon" href="/favicon_64.ico" type="image/x-icon" />
     <script src="https://cdn.tailwindcss.com"></script>


### PR DESCRIPTION
## Summary
- allow layout fragment to accept a `meta` parameter for custom metadata
- update templates to include meta blocks populated with page-specific tags
- add Open Graph tags to breed pages for richer link previews

## Testing
- `./gradlew spotlessApply`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_689200176e848321a24c8d363cc64004