### PR TITLE
Fix about page template error causing 500 response

### DIFF
--- a/src/main/resources/templates/about.html
+++ b/src/main/resources/templates/about.html
@@ -1,10 +1,16 @@
 <!DOCTYPE html>
 <html
   xmlns:th="http://www.thymeleaf.org"
-  th:replace="~{layout :: layout(~{::title}, ~{::section})}"
+  th:replace="~{layout :: layout(~{::title}, ~{::section}, ~{::meta})}"
 >
   <head>
     <title>About / Contribute</title>
+    <th:block th:fragment="meta">
+      <meta
+        name="description"
+        content="Learn about the Chicken API project and how to contribute."
+      />
+    </th:block>
   </head>
   <section class="max-w-2xl mx-auto">
     <h1 class="text-3xl font-bold mb-6 text-yellow-700 text-center">


### PR DESCRIPTION
## Summary
- pass meta fragment to layout in about.html
- add description meta tag so layout renders properly

## Testing
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68a4bdb9fd148321a6f96d2cb3411977