### PR TITLE
Add structured logging and request tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ We welcome contributions of all kinds! Here are a few ways you can help:
 - **Suggest a New Breed or Chicken:** Have a favorite breed that's not in our database? Want to add your own chicken? We'd love to see your suggestions.
 - **Improve Documentation:** See a way to make our documentation clearer? We appreciate all documentation improvements.
 
+## Logging
+
+The application uses [kotlin-logging](https://github.com/MicroUtils/kotlin-logging) with Logback. Log messages include a `requestId` for correlation and are written in plain text locally and JSON in production.
+
+Adjust log levels in `application.properties` or via the `logging.level` system property, e.g.:
+
+```properties
+logging.level.co.qwex=DEBUG
+```
+
 ## Using the API
 
 The Chicken API is free and easy to use. Check out our [API Documentation](https://chickenapi.com/swagger-ui/index.html) to get started. We're excited to see what you build!

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     implementation("com.google.auth:google-auth-library-oauth2-http:1.19.0")
     implementation("com.google.http-client:google-http-client-jackson2:1.43.3")
     implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
+    implementation("net.logstash.logback:logstash-logback-encoder:7.4")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
     implementation("org.apache.commons:commons-text:1.10.0")
     implementation("com.giffing.bucket4j.spring.boot.starter:bucket4j-spring-boot-starter:0.13.0")

--- a/src/main/kotlin/co/qwex/chickenapi/config/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/config/GlobalExceptionHandler.kt
@@ -1,0 +1,19 @@
+package co.qwex.chickenapi.config
+
+import mu.KotlinLogging
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+private val log = KotlinLogging.logger {}
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    @ExceptionHandler(Exception::class)
+    fun handleException(ex: Exception): ResponseEntity<Map<String, String>> {
+        log.error(ex) { "Unhandled exception" }
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(mapOf("error" to "Internal server error"))
+    }
+}

--- a/src/main/kotlin/co/qwex/chickenapi/config/RequestLoggingFilter.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/config/RequestLoggingFilter.kt
@@ -1,0 +1,33 @@
+package co.qwex.chickenapi.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import mu.KotlinLogging
+import org.slf4j.MDC
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.UUID
+
+private val log = KotlinLogging.logger {}
+
+@Component
+class RequestLoggingFilter : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val requestId = request.getHeader("X-Request-Id") ?: UUID.randomUUID().toString()
+        MDC.put("requestId", requestId)
+        val start = System.currentTimeMillis()
+        log.info { "Incoming ${request.method} ${request.requestURI}" }
+        try {
+            filterChain.doFilter(request, response)
+        } finally {
+            val duration = System.currentTimeMillis() - start
+            log.info { "Completed ${request.method} ${request.requestURI} ${response.status} in ${duration}ms" }
+            MDC.remove("requestId")
+        }
+    }
+}

--- a/src/main/kotlin/co/qwex/chickenapi/controller/BreedPageController.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/controller/BreedPageController.kt
@@ -1,6 +1,7 @@
 package co.qwex.chickenapi.controller
 
 import co.qwex.chickenapi.repository.BreedRepository
+import mu.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
@@ -8,6 +9,8 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.server.ResponseStatusException
+
+private val log = KotlinLogging.logger {}
 
 @Controller
 @RequestMapping("/breeds")
@@ -17,6 +20,7 @@ class BreedPageController(
 
     @GetMapping
     fun breeds(model: Model): String {
+        log.debug { "Rendering breeds page" }
         val breeds = breedRepository.getAllBreeds()
         model.addAttribute("breeds", breeds)
         return "breeds"
@@ -27,6 +31,7 @@ class BreedPageController(
         @PathVariable id: Int,
         model: Model,
     ): String {
+        log.debug { "Rendering breed detail page for id=$id" }
         val breed = breedRepository.getBreedById(id)
             ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
         model.addAttribute("breed", breed)

--- a/src/main/kotlin/co/qwex/chickenapi/controller/ChickenController.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/controller/ChickenController.kt
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
+import mu.KotlinLogging
 import org.springframework.hateoas.EntityModel
 import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo
 import org.springframework.http.HttpStatus
@@ -22,12 +23,15 @@ import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.server.ResponseStatusException
 import io.swagger.v3.oas.annotations.parameters.RequestBody as OpenApiRequestBody
 
+private val log = KotlinLogging.logger {}
+
 @RestController
 @RequestMapping("api/v1/chickens")
 class ChickenController(
     val repository: ChickenRepository,
     private val reviewQueue: ReviewQueue,
 ) {
+
     @Operation(
         summary = "Get chicken by ID",
         description = "Retrieve a single chicken by its identifier.",
@@ -56,8 +60,10 @@ class ChickenController(
     fun getChickenById(
         @PathVariable id: Int,
     ): EntityModel<Chicken> {
+        log.info { "Fetching chicken with ID $id" }
         val chickenById = repository.getChickenById(id)
-        chickenById ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Chicken with ID $id not found")
+        chickenById
+            ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Chicken with ID $id not found")
         return chickenById.let {
             val model = EntityModel.of(
                 Chicken(
@@ -103,6 +109,7 @@ class ChickenController(
         )
         @RequestBody chicken: PendingChicken,
     ) {
+        log.info { "Submitting chicken for review: ${chicken.name}" }
         reviewQueue.addChicken(chicken)
     }
 }

--- a/src/main/kotlin/co/qwex/chickenapi/controller/LandingController.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/controller/LandingController.kt
@@ -1,17 +1,22 @@
 package co.qwex.chickenapi.controller
 
+import mu.KotlinLogging
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
+
+private val log = KotlinLogging.logger {}
 
 @Controller
 class LandingController {
     @GetMapping("/")
     fun landing(): String {
+        log.debug { "Rendering landing page" }
         return "index"
     }
 
     @GetMapping("/about")
     fun about(): String {
+        log.debug { "Rendering about page" }
         return "about"
     }
 }

--- a/src/main/kotlin/co/qwex/chickenapi/repository/db/BreedRepository.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/repository/db/BreedRepository.kt
@@ -6,10 +6,10 @@ import com.google.api.services.sheets.v4.Sheets
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Repository
-private val log = KotlinLogging.logger {}
 private const val SHEET_NAME = "breeds"
 private const val MIN_COLUMN = "A"
 private const val MAX_COLUMN = "I"
+private val log = KotlinLogging.logger {}
 
 @Repository
 class GoogleSheetBreedRepository(
@@ -17,6 +17,7 @@ class GoogleSheetBreedRepository(
     @Value("\${google.sheets.db.spreadsheetId}") private val spreadsheetId: String,
 ) : BreedRepository {
     override fun getAllBreeds(): List<Breed> {
+        log.debug { "Fetching all breeds from sheet" }
         val response = sheets.spreadsheets().values()
             .get(
                 spreadsheetId,
@@ -28,7 +29,7 @@ class GoogleSheetBreedRepository(
             )
             .execute()
         val values = response.getValues() ?: return emptyList()
-        return values.drop(1).map { row ->
+        val breeds = values.drop(1).map { row ->
             Breed(
                 id = row[0]?.toString()?.toIntOrNull() ?: throw IllegalArgumentException("Invalid ID"),
                 name = row.getOrNull(1)?.toString() ?: "",
@@ -41,6 +42,8 @@ class GoogleSheetBreedRepository(
                 numEggs = row.getOrNull(8)?.toString()?.toIntOrNull(),
             )
         }
+        log.debug { "Fetched ${breeds.size} breeds" }
+        return breeds
     }
     override fun getBreedById(id: Int): Breed? {
         val response = sheets.spreadsheets().values()

--- a/src/main/kotlin/co/qwex/chickenapi/repository/db/ChickenRepository.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/repository/db/ChickenRepository.kt
@@ -3,11 +3,13 @@ package co.qwex.chickenapi.repository.db
 import co.qwex.chickenapi.model.Chicken
 import co.qwex.chickenapi.repository.ChickenRepository
 import com.google.api.services.sheets.v4.Sheets
+import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Repository
 private const val SHEET_NAME = "chickens"
 private const val MIN_COLUMN = "A"
 private const val MAX_COLUMN = "D"
+private val log = KotlinLogging.logger {}
 
 @Repository
 class ChickenRepository(
@@ -15,12 +17,13 @@ class ChickenRepository(
     @Value("\${google.sheets.db.spreadsheetId}") private val spreadsheetId: String,
 ) : ChickenRepository {
     override fun getChickenById(id: Int): Chicken? {
+        log.debug { "Fetching chicken with ID $id" }
         val rowNumber = "${id + 1}"
         val rangeWithId = "$SHEET_NAME!$MIN_COLUMN$rowNumber:$MAX_COLUMN$rowNumber"
         val response = sheets.spreadsheets().values()
             .get(spreadsheetId, rangeWithId).execute()
         val values = response.getValues() ?: return null
-        return values.map {
+        val chicken = values.map {
             Chicken(
                 id = it[0].toString().toInt(),
                 name = it[2].toString(),
@@ -28,5 +31,7 @@ class ChickenRepository(
                 imageUrl = it[3].toString(),
             )
         }.firstOrNull()
+        log.debug { "Result for chicken ID $id: $chicken" }
+        return chicken
     }
 }

--- a/src/main/kotlin/co/qwex/chickenapi/repository/db/GoogleSheetsConfig.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/repository/db/GoogleSheetsConfig.kt
@@ -5,9 +5,12 @@ import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.sheets.v4.Sheets
 import com.google.auth.http.HttpCredentialsAdapter
 import com.google.auth.oauth2.GoogleCredentials
+import mu.KotlinLogging
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+
+private val log = KotlinLogging.logger {}
 
 @Configuration
 class GoogleSheetsConfig {
@@ -19,6 +22,7 @@ class GoogleSheetsConfig {
     @ConditionalOnMissingBean(Sheets::class)
     fun sheetsService(): Sheets {
         // 1. Pick up credentials from ADC (GOOGLE_APPLICATION_CREDENTIALS)
+        log.debug { "Building Google Sheets client" }
         val credentials = GoogleCredentials
             .getApplicationDefault()
             .createScoped(listOf("https://www.googleapis.com/auth/spreadsheets"))

--- a/src/main/kotlin/co/qwex/chickenapi/service/ReviewQueue.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/service/ReviewQueue.kt
@@ -2,11 +2,13 @@ package co.qwex.chickenapi.service
 
 import com.google.api.services.sheets.v4.Sheets
 import com.google.api.services.sheets.v4.model.ValueRange
+import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
 
 private const val BREEDS_SHEET = "pending_breeds"
 private const val CHICKENS_SHEET = "pending_chickens"
+private val log = KotlinLogging.logger {}
 
 @Component
 class ReviewQueue(
@@ -17,6 +19,7 @@ class ReviewQueue(
     private val pendingChickens = mutableListOf<PendingChicken>()
 
     fun addBreed(breed: PendingBreed) {
+        log.debug { "Queueing breed for review: ${breed.name}" }
         pendingBreeds += breed
         val valueRange = ValueRange().setValues(
             listOf(
@@ -39,6 +42,7 @@ class ReviewQueue(
     }
 
     fun addChicken(chicken: PendingChicken) {
+        log.debug { "Queueing chicken for review: ${chicken.name}" }
         pendingChickens += chicken
         val valueRange = ValueRange().setValues(
             listOf(

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProfile name="!prod">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSX} [%thread] %-5level %logger - %msg [%X{requestId}]%n</pattern>
+            </encoder>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="prod">
+        <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+                <providers>
+                    <timestamp/>
+                    <loggerName/>
+                    <logLevel/>
+                    <threadName/>
+                    <message/>
+                    <mdc/>
+                    <stackTrace/>
+                </providers>
+            </encoder>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="JSON"/>
+        </root>
+    </springProfile>
+</configuration>


### PR DESCRIPTION
## Summary
- standardize KotlinLogging usage across controllers, services, and repositories without companion objects
- emit request/response logs with request IDs and structured JSON output in production
- handle uncaught exceptions with a centralized controller advice

## Testing
- `./gradlew spotlessApply`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68b65ca338e08321815fd945e4572d3d