### PR TITLE
feat: allow suggesting breed updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,17 @@ curl -X POST "https://chickenapi.com/api/v1/breeds/" \
 }'
 ```
 
+### Suggest Updates to an Existing Breed
+
+```bash
+curl -X PUT "https://chickenapi.com/api/v1/breeds/1" \
+-H "Content-Type: application/json" \
+-d '{
+  "name": "Improved Chicken",
+  "description": "Now even fluffier."
+}'
+```
+
 ### Get a Specific Chicken by ID
 
 ```bash

--- a/src/main/kotlin/co/qwex/chickenapi/controller/BreedController.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/controller/BreedController.kt
@@ -1,6 +1,7 @@
 package co.qwex.chickenapi.controller
 
 import co.qwex.chickenapi.service.PendingBreed
+import co.qwex.chickenapi.service.PendingBreedUpdate
 import co.qwex.chickenapi.service.ReviewQueue
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.ArraySchema
@@ -17,6 +18,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -137,6 +139,40 @@ class BreedController(
             model.add(linkTo(BreedController::class.java).slash(id).withSelfRel())
             model
         }
+    }
+
+    @Operation(
+        summary = "Suggest updates for a breed",
+        description = "Propose changes to an existing breed. Suggestions are added to a review queue.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "202", description = "Update accepted for review"),
+            ApiResponse(responseCode = "400", description = "Invalid breed data"),
+        ],
+    )
+    @PutMapping("{id}")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    fun suggestBreedUpdate(
+        @PathVariable id: Int,
+        @OpenApiRequestBody(
+            required = true,
+            description = "Suggested updates to the breed",
+            content = [
+                Content(
+                    mediaType = "application/json",
+                    schema = Schema(implementation = PendingBreedUpdate::class),
+                    examples = [
+                        ExampleObject(
+                            value = """{"name":"Silkie Deluxe","description":"Extra fluffy"}""",
+                        ),
+                    ],
+                ),
+            ],
+        )
+        @RequestBody update: PendingBreedUpdate,
+    ) {
+        reviewQueue.addBreedUpdate(update.copy(id = id))
     }
 
     @Operation(

--- a/src/main/kotlin/co/qwex/chickenapi/service/ReviewQueue.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/service/ReviewQueue.kt
@@ -7,61 +7,84 @@ import org.springframework.stereotype.Component
 
 private const val BREEDS_SHEET = "pending_breeds"
 private const val CHICKENS_SHEET = "pending_chickens"
+private const val BREED_UPDATES_SHEET = "pending_breed_updates"
 
 @Component
 class ReviewQueue(
     private val sheets: Sheets,
     @Value("\${google.sheets.db.spreadsheetId}") private val spreadsheetId: String,
 ) {
-    private val pendingBreeds = mutableListOf<PendingBreed>()
-    private val pendingChickens = mutableListOf<PendingChicken>()
-
     fun addBreed(breed: PendingBreed) {
-        pendingBreeds += breed
-        val valueRange = ValueRange().setValues(
+        appendRow(
+            BREEDS_SHEET,
             listOf(
-                listOf(
-                    breed.name,
-                    breed.origin,
-                    breed.eggColor,
-                    breed.eggSize,
-                    breed.eggNumber,
-                    breed.temperament,
-                    breed.description,
-                    breed.imageUrl,
-                ),
+                breed.name,
+                breed.origin,
+                breed.eggColor,
+                breed.eggSize,
+                breed.eggNumber,
+                breed.temperament,
+                breed.description,
+                breed.imageUrl,
             ),
         )
-        sheets.spreadsheets().values()
-            .append(spreadsheetId, "$BREEDS_SHEET!A1", valueRange)
-            .setValueInputOption("USER_ENTERED")
-            .execute()
+    }
+
+    fun addBreedUpdate(update: PendingBreedUpdate) {
+        appendRow(
+            BREED_UPDATES_SHEET,
+            listOf(
+                update.id,
+                update.name,
+                update.origin,
+                update.eggColor,
+                update.eggSize,
+                update.eggNumber,
+                update.temperament,
+                update.description,
+                update.imageUrl,
+            ),
+        )
     }
 
     fun addChicken(chicken: PendingChicken) {
-        pendingChickens += chicken
-        val valueRange = ValueRange().setValues(
+        appendRow(
+            CHICKENS_SHEET,
             listOf(
-                listOf(
-                    chicken.name,
-                    chicken.breedId,
-                    chicken.imageUrl,
-                ),
+                chicken.name,
+                chicken.breedId,
+                chicken.imageUrl,
             ),
         )
-        sheets.spreadsheets().values()
-            .append(spreadsheetId, "$CHICKENS_SHEET!A1", valueRange)
-            .setValueInputOption("USER_ENTERED")
-            .execute()
     }
 
-    fun getBreeds(): List<PendingBreed> = pendingBreeds.toList()
+    private fun appendRow(sheetName: String, row: List<Any?>) {
+        val valueRange = ValueRange()
+            .setMajorDimension("ROWS")
+            .setValues(listOf(row))
 
-    fun getChickens(): List<PendingChicken> = pendingChickens.toList()
+        sheets.spreadsheets().values()
+            .append(spreadsheetId, sheetName, valueRange)
+            .setValueInputOption("USER_ENTERED")
+            .setInsertDataOption("INSERT_ROWS")
+            .execute()
+    }
 }
 
 data class PendingBreed(
     val name: String,
+    val origin: String?,
+    val eggColor: String?,
+    val eggSize: String?,
+    val eggNumber: Int?,
+    val temperament: String?,
+    val description: String?,
+    val imageUrl: String?,
+)
+
+data class PendingBreedUpdate(
+    val id: Int = 0,
+    val name: String?,
     val origin: String?,
     val eggColor: String?,
     val eggSize: String?,

--- a/src/test/kotlin/co/qwex/chickenapi/controller/ChickenControllerTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/controller/ChickenControllerTests.kt
@@ -1,10 +1,11 @@
 import co.qwex.chickenapi.ChickenApiApplication
 import co.qwex.chickenapi.config.TestConfig
-import co.qwex.chickenapi.service.ReviewQueue
 import com.google.api.services.sheets.v4.Sheets
+import com.google.api.services.sheets.v4.model.AppendValuesResponse
 import com.google.api.services.sheets.v4.model.ValueRange
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.eq
 import org.mockito.Mockito
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -20,9 +21,6 @@ class ChickenControllerTests {
     @Autowired
     lateinit var mockMvc: MockMvc
 
-    @Autowired
-    lateinit var reviewQueue: ReviewQueue
-
     @MockitoBean(answers = org.mockito.Answers.RETURNS_DEEP_STUBS)
     lateinit var sheets: Sheets
 
@@ -30,7 +28,7 @@ class ChickenControllerTests {
         val valueRange = ValueRange().setValues(values)
         val range = "chickens!A${id + 1}:D${id + 1}"
         Mockito.`when`(
-            sheets.spreadsheets().values().get(anyString(), Mockito.eq(range)).execute(),
+            sheets.spreadsheets().values().get(anyString(), eq(range)).execute(),
         ).thenReturn(valueRange)
     }
 
@@ -55,11 +53,16 @@ class ChickenControllerTests {
             "imageUrl":"img"
         }"""
 
+        val values = sheets.spreadsheets().values()
+        val append = Mockito.mock(Sheets.Spreadsheets.Values.Append::class.java)
+        Mockito.`when`(values.append(anyString(), anyString(), Mockito.any())).thenReturn(append)
+        Mockito.`when`(append.setValueInputOption(anyString())).thenReturn(append)
+        Mockito.`when`(append.setInsertDataOption(anyString())).thenReturn(append)
+        Mockito.`when`(append.execute()).thenReturn(AppendValuesResponse())
+
         mockMvc.post("/api/v1/chickens") {
             contentType = org.springframework.http.MediaType.APPLICATION_JSON
             content = payload
         }.andExpect { status { isAccepted() } }
-
-        assert(reviewQueue.getChickens().any { it.name == "NewChicken" })
     }
 }

--- a/src/test/kotlin/co/qwex/chickenapi/service/ReviewQueueTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/service/ReviewQueueTests.kt
@@ -1,10 +1,10 @@
 import co.qwex.chickenapi.ChickenApiApplication
 import co.qwex.chickenapi.config.TestConfig
 import co.qwex.chickenapi.service.PendingBreed
+import co.qwex.chickenapi.service.PendingBreedUpdate
 import co.qwex.chickenapi.service.PendingChicken
 import co.qwex.chickenapi.service.ReviewQueue
 import com.google.api.services.sheets.v4.Sheets
-import com.google.api.services.sheets.v4.Sheets.Spreadsheets.Values
 import com.google.api.services.sheets.v4.model.AppendValuesResponse
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.any
@@ -32,6 +32,7 @@ class ReviewQueueTests {
         val append = Mockito.mock(Sheets.Spreadsheets.Values.Append::class.java)
         Mockito.`when`(values.append(anyString(), anyString(), any())).thenReturn(append)
         Mockito.`when`(append.setValueInputOption(anyString())).thenReturn(append)
+        Mockito.`when`(append.setInsertDataOption(anyString())).thenReturn(append)
         Mockito.`when`(append.execute()).thenReturn(AppendValuesResponse())
 
         val breed = PendingBreed(
@@ -46,14 +47,45 @@ class ReviewQueueTests {
         )
 
         reviewQueue.addBreed(breed)
-
-        assert(reviewQueue.getBreeds().contains(breed))
         Mockito.verify(values).append(
             Mockito.eq(spreadsheetId),
-            Mockito.eq("pending_breeds!A1"),
+            Mockito.eq("pending_breeds"),
             Mockito.any(),
         )
         Mockito.verify(append).setValueInputOption("USER_ENTERED")
+        Mockito.verify(append).setInsertDataOption("INSERT_ROWS")
+        Mockito.verify(append).execute()
+    }
+
+    @Test
+    fun `add breed update enqueues and writes`() {
+        val values = sheets.spreadsheets().values()
+        val append = Mockito.mock(Sheets.Spreadsheets.Values.Append::class.java)
+        Mockito.`when`(values.append(anyString(), anyString(), any())).thenReturn(append)
+        Mockito.`when`(append.setValueInputOption(anyString())).thenReturn(append)
+        Mockito.`when`(append.setInsertDataOption(anyString())).thenReturn(append)
+        Mockito.`when`(append.execute()).thenReturn(AppendValuesResponse())
+
+        val update = PendingBreedUpdate(
+            id = 1,
+            name = "Updated",
+            origin = null,
+            eggColor = null,
+            eggSize = null,
+            eggNumber = null,
+            temperament = null,
+            description = null,
+            imageUrl = null,
+        )
+
+        reviewQueue.addBreedUpdate(update)
+        Mockito.verify(values).append(
+            Mockito.eq(spreadsheetId),
+            Mockito.eq("pending_breed_updates"),
+            Mockito.any(),
+        )
+        Mockito.verify(append).setValueInputOption("USER_ENTERED")
+        Mockito.verify(append).setInsertDataOption("INSERT_ROWS")
         Mockito.verify(append).execute()
     }
 
@@ -63,6 +95,7 @@ class ReviewQueueTests {
         val append = Mockito.mock(Sheets.Spreadsheets.Values.Append::class.java)
         Mockito.`when`(values.append(anyString(), anyString(), any())).thenReturn(append)
         Mockito.`when`(append.setValueInputOption(anyString())).thenReturn(append)
+        Mockito.`when`(append.setInsertDataOption(anyString())).thenReturn(append)
         Mockito.`when`(append.execute()).thenReturn(AppendValuesResponse())
 
         val chicken = PendingChicken(
@@ -72,14 +105,13 @@ class ReviewQueueTests {
         )
 
         reviewQueue.addChicken(chicken)
-
-        assert(reviewQueue.getChickens().contains(chicken))
         Mockito.verify(values).append(
             Mockito.eq(spreadsheetId),
-            Mockito.eq("pending_chickens!A1"),
+            Mockito.eq("pending_chickens"),
             Mockito.any(),
         )
         Mockito.verify(append).setValueInputOption("USER_ENTERED")
+        Mockito.verify(append).setInsertDataOption("INSERT_ROWS")
         Mockito.verify(append).execute()
     }
 }


### PR DESCRIPTION
## Summary
- allow clients to submit breed update suggestions via `PUT /api/v1/breeds/{id}`
- queue breed update suggestions in Google Sheets using idiomatic append API
- drop in-memory ReviewQueue lists in favor of direct appends and update tests accordingly

## Testing
- `./gradlew spotlessApply`
- `./gradlew test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68bf537795ec8321916f595c77caf3a7