### PR TITLE
Add internal updated at timestamp to entities

### DIFF
--- a/src/main/kotlin/co/qwex/chickenapi/model/Breed.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/model/Breed.kt
@@ -1,5 +1,7 @@
 package co.qwex.chickenapi.model
 
+import java.time.Instant
+
 data class Breed(
     val id: Int,
     val name: String,
@@ -10,4 +12,5 @@ data class Breed(
     val description: String?,
     val imageUrl: String?,
     val numEggs: Int?,
+    val updatedAt: Instant? = null,
 )

--- a/src/main/kotlin/co/qwex/chickenapi/model/Chicken.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/model/Chicken.kt
@@ -1,8 +1,11 @@
 package co.qwex.chickenapi.model
 
+import java.time.Instant
+
 data class Chicken(
     val id: Int,
     val name: String,
     val breedId: Int,
     val imageUrl: String,
+    val updatedAt: Instant? = null,
 )

--- a/src/main/kotlin/co/qwex/chickenapi/model/ChickenFactsRecord.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/model/ChickenFactsRecord.kt
@@ -11,6 +11,7 @@ data class ChickenFactsRecord(
     val fact: String?,
     val sourceUrl: String?,
     val errorMessage: String? = null,
+    val updatedAt: Instant? = null,
 )
 
 enum class AgentRunOutcome {

--- a/src/main/kotlin/co/qwex/chickenapi/repository/BreedRepository.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/repository/BreedRepository.kt
@@ -14,4 +14,9 @@ interface BreedRepository : DataRepository<Breed, Int> {
     override fun create(entity: Breed) {
         throw UnsupportedOperationException("Create not supported for BreedRepository")
     }
+
+    /**
+     * Updates an existing breed. The updatedAt timestamp will be set automatically.
+     */
+    override fun update(entity: Breed)
 }

--- a/src/main/kotlin/co/qwex/chickenapi/repository/DataRepository.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/repository/DataRepository.kt
@@ -32,4 +32,13 @@ interface DataRepository<T, ID> {
      * @param entity the entity to create
      */
     fun create(entity: T)
+
+    /**
+     * Updates an existing entity in the data store.
+     *
+     * @param entity the entity to update
+     */
+    fun update(entity: T) {
+        throw UnsupportedOperationException("Update not supported for this repository")
+    }
 }

--- a/src/main/kotlin/co/qwex/chickenapi/repository/db/ChickenFactsSheetRepository.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/repository/db/ChickenFactsSheetRepository.kt
@@ -10,8 +10,8 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Repository
 import java.time.Instant
 
-private const val CHICKEN_FACTS_RANGE = "chicken_facts!A1:I1"
-private const val CHICKEN_FACTS_DATA_RANGE = "chicken_facts!A:I"
+private const val CHICKEN_FACTS_RANGE = "chicken_facts!A1:J1"
+private const val CHICKEN_FACTS_DATA_RANGE = "chicken_facts!A:J"
 
 @Repository
 class ChickenFactsSheetRepository(
@@ -21,6 +21,7 @@ class ChickenFactsSheetRepository(
     private val log = KotlinLogging.logger {}
 
     override fun create(entity: ChickenFactsRecord) {
+        val updatedAt = Instant.now()
         val row = listOf(
             entity.runId,
             entity.startedAt.toString(),
@@ -31,6 +32,7 @@ class ChickenFactsSheetRepository(
             entity.fact.orEmpty(),
             entity.sourceUrl.orEmpty(),
             entity.errorMessage.orEmpty(),
+            updatedAt.toString(),
         )
 
         val valueRange = ValueRange().setValues(listOf(row))
@@ -114,6 +116,7 @@ class ChickenFactsSheetRepository(
         val fact = row.stringAt(6, trim = false)
         val sourceUrl = row.stringAt(7, trim = false)
         val errorMessage = row.stringAt(8, trim = false)
+        val updatedAt = row.instantAt(9)
 
         return ChickenFactsRecord(
             runId = runId,
@@ -124,6 +127,7 @@ class ChickenFactsSheetRepository(
             fact = fact,
             sourceUrl = sourceUrl,
             errorMessage = errorMessage,
+            updatedAt = updatedAt,
         )
     }
 

--- a/src/main/kotlin/co/qwex/chickenapi/repository/db/ChickenRepository.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/repository/db/ChickenRepository.kt
@@ -6,9 +6,11 @@ import com.google.api.services.sheets.v4.Sheets
 import mu.KotlinLogging
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Repository
+import java.time.Instant
+
 private const val SHEET_NAME = "chickens"
 private const val MIN_COLUMN = "A"
-private const val MAX_COLUMN = "D"
+private const val MAX_COLUMN = "E"
 private val log = KotlinLogging.logger {}
 
 @Repository
@@ -28,14 +30,21 @@ class ChickenRepository(
         val breedId = row.getOrNull(1)?.toString()?.toIntOrNull() ?: return null
         val name = row.getOrNull(2)?.toString()?.takeIf { it.isNotBlank() } ?: return null
         val imageUrl = row.getOrNull(3)?.toString().orEmpty()
+        val updatedAt = row.getOrNull(4)?.toString()?.parseInstantOrNull()
 
         val chicken = Chicken(
             id = chickenId,
             name = name,
             breedId = breedId,
             imageUrl = imageUrl,
+            updatedAt = updatedAt,
         )
         log.debug { "Result for chicken ID $id: $chicken" }
         return chicken
     }
 }
+
+private fun String.parseInstantOrNull(): Instant? =
+    takeIf { it.isNotBlank() }?.let {
+        runCatching { Instant.parse(it) }.getOrNull()
+    }

--- a/src/test/kotlin/co/qwex/chickenapi/controller/BreedControllerTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/controller/BreedControllerTests.kt
@@ -29,13 +29,13 @@ class BreedControllerTests {
     private fun mockBreedListResponse(values: List<List<Any>>) {
         val valueRange = ValueRange().setValues(values)
         Mockito.`when`(
-            sheets.spreadsheets().values().get(anyString(), Mockito.eq("breeds!A1:I")).execute(),
+            sheets.spreadsheets().values().get(anyString(), Mockito.eq("breeds!A1:J")).execute(),
         ).thenReturn(valueRange)
     }
 
     private fun mockBreedByIdResponse(id: Int, values: List<List<Any>>) {
         val valueRange = ValueRange().setValues(values)
-        val range = "breeds!A${id + 1}:I${id + 1}"
+        val range = "breeds!A${id + 1}:J${id + 1}"
         Mockito.`when`(
             sheets.spreadsheets().values().get(anyString(), Mockito.eq(range)).execute(),
         ).thenReturn(valueRange)

--- a/src/test/kotlin/co/qwex/chickenapi/controller/ChickenControllerTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/controller/ChickenControllerTests.kt
@@ -28,7 +28,7 @@ class ChickenControllerTests {
 
     private fun mockChickenById(id: Int, values: List<List<Any>>) {
         val valueRange = ValueRange().setValues(values)
-        val range = "chickens!A${id + 1}:D${id + 1}"
+        val range = "chickens!A${id + 1}:E${id + 1}"
         Mockito.`when`(
             sheets.spreadsheets().values().get(anyString(), Mockito.eq(range)).execute(),
         ).thenReturn(valueRange)

--- a/src/test/kotlin/co/qwex/chickenapi/repository/db/ChickenFactsSheetRepositoryTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/repository/db/ChickenFactsSheetRepositoryTests.kt
@@ -40,7 +40,7 @@ class ChickenFactsSheetRepositoryTests {
         val valueRangeCaptor = ArgumentCaptor.forClass(ValueRange::class.java)
         Mockito.verify(values).append(
             Mockito.eq("test-sheet"),
-            Mockito.eq("chicken_facts!A1:I1"),
+            Mockito.eq("chicken_facts!A1:J1"),
             valueRangeCaptor.capture(),
         )
         Mockito.verify(append).setValueInputOption("USER_ENTERED")

--- a/src/test/kotlin/co/qwex/chickenapi/repository/db/ChickenRepositoryTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/repository/db/ChickenRepositoryTests.kt
@@ -30,7 +30,7 @@ class ChickenRepositoryTests {
             ),
         )
         `when`(
-            sheets.spreadsheets().values().get(eq("test-sheet"), eq("chickens!A2:D2")).execute(),
+            sheets.spreadsheets().values().get(eq("test-sheet"), eq("chickens!A2:E2")).execute(),
         ).thenReturn(valueRange)
 
         val chicken = repository.getChickenById(1)
@@ -49,7 +49,7 @@ class ChickenRepositoryTests {
             ),
         )
         `when`(
-            sheets.spreadsheets().values().get(eq("test-sheet"), eq("chickens!A2:D2")).execute(),
+            sheets.spreadsheets().values().get(eq("test-sheet"), eq("chickens!A2:E2")).execute(),
         ).thenReturn(incompleteRow)
 
         val chicken = repository.getChickenById(1)


### PR DESCRIPTION
Add `updatedAt` timestamp to all entities and implement an efficient `update` method for `Breed` using the Sheets API.

The `updatedAt` field is for internal tracking only and is not exposed via the API. The `update` method for `Breed` leverages the Sheets API's `update` functionality for single-row efficiency. The field is nullable to handle existing data gracefully.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc64bc44-2fc3-4e58-bf3d-f0f2ee9f8572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dc64bc44-2fc3-4e58-bf3d-f0f2ee9f8572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

