### PR TITLE
Remove unused BreedResearchAgentProperties from Koog breed research HTTP client

### DIFF
--- a/src/main/kotlin/co/qwex/chickenapi/ai/KoogHttpClientConfiguration.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/ai/KoogHttpClientConfiguration.kt
@@ -1,6 +1,5 @@
 package co.qwex.chickenapi.ai
 
-import co.qwex.chickenapi.config.BreedResearchAgentProperties
 import co.qwex.chickenapi.config.KoogAgentProperties
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
@@ -36,7 +35,7 @@ class KoogHttpClientConfiguration {
     @ConditionalOnExpression(
         "\${koog.breed-research-agent.enabled:true} && '\${koog.breed-research-agent.client-id:}' != '' && '\${koog.breed-research-agent.client-secret:}' != ''",
     )
-    fun koogBreedResearchHttpClient(properties: BreedResearchAgentProperties): HttpClient =
+    fun koogBreedResearchHttpClient(properties: KoogAgentProperties): HttpClient =
         createAuthorizedClient(
             clientId = properties.clientId.orEmpty(),
             clientSecret = properties.clientSecret.orEmpty(),


### PR DESCRIPTION
### Motivation
- Remove an unused `BreedResearchAgentProperties` parameter from the `koogBreedResearchHttpClient` bean and ensure conditional wiring via `@ConditionalOnExpression` remains intact because the bean did not need the specialized properties class.

### Description
- Replaced the `BreedResearchAgentProperties` parameter with `KoogAgentProperties` in `koogBreedResearchHttpClient` and removed the unused import, keeping the existing `@ConditionalOnExpression` unchanged; the client still reads credentials via `properties.clientId` and `properties.clientSecret`.
- The `@ConditionalOnExpression` continues to evaluate property placeholders (including `koog.breed-research-agent.*`) at configuration time, which does not require the presence of the `BreedResearchAgentProperties` type, so conditional wiring is preserved.

### Testing
- Ran `./gradlew spotlessApply` which failed (build output: `25.0.1`).
- Ran `./gradlew test --no-daemon` which failed (build output: `25.0.1`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980d8b478b88321a7404584222e9741)