### PR TITLE
Remove Cloudflare Access headers and client credentials from Koog agents

### DIFF
--- a/docs/epics/BREED_RESEARCH_AGENT_EPIC.md
+++ b/docs/epics/BREED_RESEARCH_AGENT_EPIC.md
@@ -426,7 +426,7 @@ koog.breed-research-agent.max-agent-iterations=100
 koog.breed-research-agent.max-tool-calls=8
 ```
 
-> **Note:** The breed research agent reuses the shared Koog credentials (`koog.agent.api-key` or `koog.agent.client-id/client-secret`).
+> **Note:** The breed research agent reuses the shared Koog credentials (`koog.agent.api-key` or `koog.agent.access-token`).
 
 ---
 

--- a/docs/investigations/BREED_RESEARCH_NOT_RUNNING.md
+++ b/docs/investigations/BREED_RESEARCH_NOT_RUNNING.md
@@ -56,12 +56,11 @@ val returnResult by node<String, String>("return_result") { message ->
 
 ---
 
-### 2. Missing `OLLAMA_API_KEY` or Client Credentials (Secondary - If Agent Not Ready)
+### 2. Missing `OLLAMA_API_KEY` or Access Token (Secondary - If Agent Not Ready)
 
 **Evidence**:
 - `application.properties:31`: `koog.agent.api-key=${OLLAMA_API_KEY:}`
-- `application.properties:32`: `koog.agent.client-id=${OLLAMA_CLIENT_ID:}`
-- `application.properties:33`: `koog.agent.client-secret=${OLLAMA_CLIENT_SECRET:}`
+- `application.properties:32`: `koog.agent.access-token=${KOOG_AGENT_ACCESS_TOKEN:}`
 - The syntax `${VAR:}` means: use the environment variable, or default to empty string
 - Empty string fails the `isNotBlank()` check
 
@@ -69,9 +68,9 @@ val returnResult by node<String, String>("return_result") { message ->
 ```
 KoogBreedResearchAgent.kt:55-63:
   val apiKey = agentProperties.apiKey?.takeIf { it.isNotBlank() }
-  val hasCloudflareCredentials = clientId != null && clientSecret != null
-  if (apiKey == null && !hasCloudflareCredentials) {
-      log.warn { "koog.agent.api-key or koog.agent.client-id/client-secret is not set; Breed research agent will be skipped." }
+  val accessToken = agentProperties.accessToken?.takeIf { it.isNotBlank() }
+  if (apiKey == null && accessToken == null) {
+      log.warn { "koog.agent.api-key or koog.agent.access-token is not set; Breed research agent will be skipped." }
   }
 ```
 
@@ -82,7 +81,7 @@ When API key is missing:
 
 **Expected Log Output**:
 ```
-WARN  - koog.agent.api-key or koog.agent.client-id/client-secret is not set; Breed research agent will be skipped.
+WARN  - koog.agent.api-key or koog.agent.access-token is not set; Breed research agent will be skipped.
 INFO  - Breed research agent is not ready, skipping run.
 ```
 
@@ -113,9 +112,8 @@ The scheduler runs only at midnight UTC daily (`0 0 0 * * *`). There is currentl
 
 | Variable | Purpose | Required |
 |----------|---------|----------|
-| `OLLAMA_API_KEY` | API key for LLM authentication (optional if using client credentials) | **Yes** |
-| `OLLAMA_CLIENT_ID` | Cloudflare Access client ID | Optional |
-| `OLLAMA_CLIENT_SECRET` | Cloudflare Access client secret | Optional |
+| `OLLAMA_API_KEY` | API key for LLM authentication (optional if using access token) | **Yes** |
+| `KOOG_AGENT_ACCESS_TOKEN` | Access token for LLM authentication | Optional |
 
 ### Application Properties (with defaults)
 

--- a/src/main/kotlin/co/qwex/chickenapi/ai/KoogBreedResearchAgent.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/ai/KoogBreedResearchAgent.kt
@@ -55,30 +55,16 @@ class KoogBreedResearchAgent(
         }
 
         val apiKey = agentProperties.apiKey?.takeIf { it.isNotBlank() }
-        val clientId = agentProperties.clientId?.takeIf { it.isNotBlank() }
-        val clientSecret = agentProperties.clientSecret?.takeIf { it.isNotBlank() }
-        val hasCloudflareCredentials = clientId != null && clientSecret != null
-        if (apiKey == null && !hasCloudflareCredentials) {
+        val accessToken = agentProperties.accessToken?.takeIf { it.isNotBlank() }
+        if (apiKey == null && accessToken == null) {
             val missingFields = buildList {
                 add("koog.agent.api-key")
-                if (clientId == null) {
-                    add("koog.agent.client-id")
-                }
-                if (clientSecret == null) {
-                    add("koog.agent.client-secret")
-                }
+                add("koog.agent.access-token")
             }
             val missingEnvVars = buildList {
                 add("KOOG_AGENT_API_KEY")
                 add("OLLAMA_API_KEY")
-                if (clientId == null) {
-                    add("KOOG_AGENT_CLIENT_ID")
-                    add("OLLAMA_CLIENT_ID")
-                }
-                if (clientSecret == null) {
-                    add("KOOG_AGENT_CLIENT_SECRET")
-                    add("OLLAMA_CLIENT_SECRET")
-                }
+                add("KOOG_AGENT_ACCESS_TOKEN")
             }
             log.warn {
                 "Missing Koog agent credentials: ${missingFields.joinToString()} " +

--- a/src/main/kotlin/co/qwex/chickenapi/ai/KoogChickenFactsAgent.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/ai/KoogChickenFactsAgent.kt
@@ -54,30 +54,16 @@ class KoogChickenFactsAgent(
         }
 
         val apiKey = properties.apiKey?.takeIf { it.isNotBlank() }
-        val clientId = properties.clientId?.takeIf { it.isNotBlank() }
-        val clientSecret = properties.clientSecret?.takeIf { it.isNotBlank() }
-        val hasCloudflareCredentials = clientId != null && clientSecret != null
-        if (apiKey == null && !hasCloudflareCredentials) {
+        val accessToken = properties.accessToken?.takeIf { it.isNotBlank() }
+        if (apiKey == null && accessToken == null) {
             val missingFields = buildList {
                 add("koog.agent.api-key")
-                if (clientId == null) {
-                    add("koog.agent.client-id")
-                }
-                if (clientSecret == null) {
-                    add("koog.agent.client-secret")
-                }
+                add("koog.agent.access-token")
             }
             val missingEnvVars = buildList {
                 add("KOOG_AGENT_API_KEY")
                 add("OLLAMA_API_KEY")
-                if (clientId == null) {
-                    add("KOOG_AGENT_CLIENT_ID")
-                    add("OLLAMA_CLIENT_ID")
-                }
-                if (clientSecret == null) {
-                    add("KOOG_AGENT_CLIENT_SECRET")
-                    add("OLLAMA_CLIENT_SECRET")
-                }
+                add("KOOG_AGENT_ACCESS_TOKEN")
             }
             log.warn {
                 "Missing Koog agent credentials: ${missingFields.joinToString()} " +

--- a/src/main/kotlin/co/qwex/chickenapi/ai/KoogHttpClientConfiguration.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/ai/KoogHttpClientConfiguration.kt
@@ -22,21 +22,19 @@ class KoogHttpClientConfiguration {
     @Bean
     @Qualifier("koogChickenFactsHttpClient")
     @ConditionalOnExpression(
-        "\${koog.agent.enabled:true} && (('\${koog.agent.client-id:}' != '' && '\${koog.agent.client-secret:}' != '') || '\${koog.agent.api-key:}' != '')",
+        "\${koog.agent.enabled:true} && ('\${koog.agent.api-key:}' != '' || '\${koog.agent.access-token:}' != '')",
     )
     fun koogChickenFactsHttpClient(properties: KoogAgentProperties): HttpClient =
         createAuthorizedClient(
             apiKey = properties.apiKey.orEmpty(),
             accessToken = properties.accessToken.orEmpty(),
-            clientId = properties.clientId.orEmpty(),
-            clientSecret = properties.clientSecret.orEmpty(),
             extraHeaders = properties.extraHeaders,
         )
 
     @Bean
     @Qualifier("koogBreedResearchHttpClient")
     @ConditionalOnExpression(
-        "\${koog.breed-research-agent.enabled:true} && (('\${koog.agent.client-id:}' != '' && '\${koog.agent.client-secret:}' != '') || '\${koog.agent.api-key:}' != '')",
+        "\${koog.breed-research-agent.enabled:true} && ('\${koog.agent.api-key:}' != '' || '\${koog.agent.access-token:}' != '')",
     )
     fun koogBreedResearchHttpClient(
         agentProperties: KoogAgentProperties,
@@ -44,16 +42,12 @@ class KoogHttpClientConfiguration {
         createAuthorizedClient(
             apiKey = agentProperties.apiKey.orEmpty(),
             accessToken = agentProperties.accessToken.orEmpty(),
-            clientId = agentProperties.clientId.orEmpty(),
-            clientSecret = agentProperties.clientSecret.orEmpty(),
             extraHeaders = agentProperties.extraHeaders,
         )
 
     private fun createAuthorizedClient(
         apiKey: String,
         accessToken: String,
-        clientId: String,
-        clientSecret: String,
         extraHeaders: Map<String, String>,
     ): HttpClient =
         HttpClient(CIO) {
@@ -69,12 +63,6 @@ class KoogHttpClientConfiguration {
                 }
                 if (authorizationValue != null && !hasAuthorizationHeader) {
                     header("Authorization", authorizationValue)
-                }
-                if (clientId.isNotBlank()) {
-                    header("CF-Access-Client-Id", clientId)
-                }
-                if (clientSecret.isNotBlank()) {
-                    header("CF-Access-Client-Secret", clientSecret)
                 }
                 normalizedExtraHeaders
                     .filterNot { (key) -> key.equals("Authorization", ignoreCase = true) && authorizationValue != null }

--- a/src/main/kotlin/co/qwex/chickenapi/config/KoogAgentProperties.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/config/KoogAgentProperties.kt
@@ -16,8 +16,6 @@ data class KoogAgentProperties(
     val prompt: String = "Find an interesting, fun, or quirky fact about chickens. Look for trivia, surprising behaviors, historical tidbits, or amusing chicken stories rather than scientific research papers. Cite your sources. Format your response as a markdown. stay on topic about chickens. only return one fact.",
     val apiKey: String? = null,
     val accessToken: String? = null,
-    val clientId: String? = null,
-    val clientSecret: String? = null,
     val extraHeaders: Map<String, String> = emptyMap(),
     val webSearchMaxResults: Int = 3,
     val maxAgentIterations: Int = 100,

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,9 +31,6 @@ koog.agent.embedding-model=nomic-embed-text
 koog.agent.prompt=Find the coolest new facts about chickens and cite your sources in markdown bullet points.
 koog.agent.api-key=${KOOG_AGENT_API_KEY:${OLLAMA_API_KEY:}}
 koog.agent.access-token=${KOOG_AGENT_ACCESS_TOKEN:}
-koog.agent.client-id=${KOOG_AGENT_CLIENT_ID:${OLLAMA_CLIENT_ID:}}
-koog.agent.client-secret=${KOOG_AGENT_CLIENT_SECRET:${OLLAMA_CLIENT_SECRET:}}
-koog.agent.extra-headers.CF-Access-Jwt-Assertion=${KOOG_AGENT_ACCESS_JWT_ASSERTION:}
 koog.agent.web-search-max-results=3
 koog.agent.max-agent-iterations=100
 


### PR DESCRIPTION
### Motivation
- The Cloudflare/Cloudflare Access-specific client-id/secret and CF headers are no longer used for Koog/Ollama integration and should be removed to simplify configuration and harden defaults.
- Credential validation should rely on a single, clear mechanism (API key or access token) to reduce duplication and confusion across agents.

### Description
- Removed `clientId`/`clientSecret` fields and Cloudflare header handling from `KoogAgentProperties` and `KoogHttpClientConfiguration`, and stopped injecting `CF-Access-Client-Id`/`CF-Access-Client-Secret` headers. 
- Simplified conditional bean creation expressions to require only `koog.agent.api-key` or `koog.agent.access-token` and removed `extra-headers` usage for Cloudflare JWTs in `application.properties`.
- Updated `KoogChickenFactsAgent` and `KoogBreedResearchAgent` initialization checks and warning messages to validate `apiKey` or `accessToken` only (and updated related missing-env var messages).
- Aligned documentation in `docs/investigations/BREED_RESEARCH_NOT_RUNNING.md` and `docs/epics/BREED_RESEARCH_AGENT_EPIC.md` to reflect the new credential requirements.

### Testing
- Ran formatting with `./gradlew spotlessApply` using Java 21 and it completed successfully. 
- Ran unit/integration tests with `./gradlew test --no-daemon` using Java 21 and the build completed successfully (tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985f3bb1b4c8321b50ab30b1aaad92a)