### PR TITLE
Add duplicate fact detection with retry loop in chicken facts agent

### DIFF
--- a/src/main/kotlin/co/qwex/chickenapi/ai/ChickenFactDuplicateChecker.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/ai/ChickenFactDuplicateChecker.kt
@@ -1,0 +1,103 @@
+package co.qwex.chickenapi.ai
+
+import co.qwex.chickenapi.repository.ChickenFactsRepository
+import kotlinx.serialization.Serializable
+import mu.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import kotlin.math.sqrt
+
+interface ChickenFactDuplicateCheckService {
+    suspend fun checkFactForDuplicate(fact: String): FactDuplicateCheckResult
+}
+
+@Serializable
+data class SimilarFactMatch(
+    val runId: String,
+    val fact: String,
+    val sourceUrl: String?,
+    val similarity: Double,
+)
+
+@Serializable
+data class FactDuplicateCheckResult(
+    val hasHit: Boolean,
+    val threshold: Double,
+    val topSimilarity: Double?,
+    val matches: List<SimilarFactMatch>,
+)
+
+@Service
+class ChickenFactDuplicateChecker(
+    private val embeddingService: OllamaEmbeddingService,
+    private val chickenFactsRepository: ChickenFactsRepository,
+    @Value("\${koog.agent.fact-dedup-threshold:0.88}")
+    private val similarityThreshold: Double,
+) : ChickenFactDuplicateCheckService {
+    private val log = KotlinLogging.logger {}
+
+    override suspend fun checkFactForDuplicate(fact: String): FactDuplicateCheckResult {
+        if (!embeddingService.isReady()) {
+            log.error { "Fact duplicate check failed because embedding service is unavailable." }
+            throw IllegalStateException("Embedding service unavailable for duplicate check")
+        }
+
+        val candidateEmbedding = embeddingService.embedFact(fact.trim())
+        if (candidateEmbedding.isNullOrEmpty()) {
+            log.error { "Fact duplicate check failed because candidate embedding could not be created." }
+            throw IllegalStateException("Unable to create embedding for candidate fact")
+        }
+
+        val matches = chickenFactsRepository.fetchAllSuccessfulChickenFacts()
+            .asSequence()
+            .mapNotNull { record ->
+                val existingFact = record.fact?.trim()?.takeIf { it.isNotBlank() } ?: return@mapNotNull null
+                val existingEmbedding = record.factEmbedding ?: return@mapNotNull null
+                val similarity = cosineSimilarity(candidateEmbedding, existingEmbedding) ?: return@mapNotNull null
+                SimilarFactMatch(
+                    runId = record.runId,
+                    fact = existingFact,
+                    sourceUrl = record.sourceUrl,
+                    similarity = similarity,
+                )
+            }
+            .filter { it.similarity >= similarityThreshold }
+            .sortedByDescending { it.similarity }
+            .toList()
+
+        return FactDuplicateCheckResult(
+            hasHit = matches.isNotEmpty(),
+            threshold = similarityThreshold,
+            topSimilarity = matches.firstOrNull()?.similarity,
+            matches = matches,
+        )
+    }
+
+    private fun cosineSimilarity(
+        left: List<Double>,
+        right: List<Double>,
+    ): Double? {
+        if (left.isEmpty() || right.isEmpty() || left.size != right.size) {
+            return null
+        }
+
+        var dotProduct = 0.0
+        var leftNormSquared = 0.0
+        var rightNormSquared = 0.0
+
+        left.indices.forEach { index ->
+            val leftValue = left[index]
+            val rightValue = right[index]
+            dotProduct += leftValue * rightValue
+            leftNormSquared += leftValue * leftValue
+            rightNormSquared += rightValue * rightValue
+        }
+
+        val denominator = sqrt(leftNormSquared) * sqrt(rightNormSquared)
+        if (denominator == 0.0) {
+            return null
+        }
+
+        return dotProduct / denominator
+    }
+}

--- a/src/test/kotlin/co/qwex/chickenapi/ai/SaveChickenFactToolTests.kt
+++ b/src/test/kotlin/co/qwex/chickenapi/ai/SaveChickenFactToolTests.kt
@@ -1,0 +1,84 @@
+package co.qwex.chickenapi.ai
+
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SaveChickenFactToolTests {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    @Test
+    fun `save tool returns duplicate metadata when duplicate exists`() {
+        val tool = SaveChickenFactTool(
+            duplicateCheckService =
+                object : ChickenFactDuplicateCheckService {
+                    override suspend fun checkFactForDuplicate(fact: String): FactDuplicateCheckResult =
+                        FactDuplicateCheckResult(
+                            hasHit = true,
+                            threshold = 0.88,
+                            topSimilarity = 0.95,
+                            matches =
+                                listOf(
+                                    SimilarFactMatch(
+                                        runId = "run-1",
+                                        fact = "Chickens can recognize over 100 faces.",
+                                        sourceUrl = "https://example.com/faces",
+                                        similarity = 0.95,
+                                    ),
+                                ),
+                        )
+                },
+        )
+
+        val resultJson = runBlocking {
+            tool.doExecute(
+                SaveChickenFactTool.Args(
+                    fact = "Chickens can remember over 100 faces.",
+                    sourceUrl = "https://example.com/new",
+                ),
+            )
+        }
+
+        val result = json.decodeFromString(SaveChickenFactTool.Result.serializer(), resultJson)
+
+        assertTrue(result.duplicateCheck.hasHit)
+        assertEquals(0.88, result.duplicateCheck.threshold)
+        assertEquals(1, result.duplicateCheck.matches.size)
+        assertEquals("run-1", result.duplicateCheck.matches.first().runId)
+    }
+
+    @Test
+    fun `save tool returns no-hit duplicate metadata when fact is unique`() {
+        val tool = SaveChickenFactTool(
+            duplicateCheckService =
+                object : ChickenFactDuplicateCheckService {
+                    override suspend fun checkFactForDuplicate(fact: String): FactDuplicateCheckResult =
+                        FactDuplicateCheckResult(
+                            hasHit = false,
+                            threshold = 0.88,
+                            topSimilarity = null,
+                            matches = emptyList(),
+                        )
+                },
+        )
+
+        val resultJson = runBlocking {
+            tool.doExecute(
+                SaveChickenFactTool.Args(
+                    fact = "Hens often communicate with their chicks before they hatch.",
+                    sourceUrl = "https://example.com/chicks",
+                ),
+            )
+        }
+
+        val result = json.decodeFromString(SaveChickenFactTool.Result.serializer(), resultJson)
+
+        assertFalse(result.duplicateCheck.hasHit)
+        assertEquals(0.88, result.duplicateCheck.threshold)
+        assertTrue(result.duplicateCheck.matches.isEmpty())
+    }
+}


### PR DESCRIPTION
### Motivation

- Prevent storing near-duplicate chicken facts by checking candidate facts against existing successful facts using embeddings and similarity.
- Surface structured duplicate metadata to the agent so the LLM can revise proposals when a duplicate is detected.
- Limit retries to avoid infinite loops and fail gracefully when duplicate retries exceed a configured cap.

### Description

- Added a new duplicate-check service `ChickenFactDuplicateChecker` and result models `SimilarFactMatch` and `FactDuplicateCheckResult` that embed a candidate fact, compute cosine similarity against stored embeddings, apply a configurable threshold (`koog.agent.fact-dedup-threshold`), and return structured metadata; the service logs and throws `IllegalStateException` if the embedding service is unavailable or embedding generation fails (`src/main/kotlin/co/qwex/chickenapi/ai/ChickenFactDuplicateChecker.kt`).
- Wired duplicate checking into the agent: inject `ChickenFactDuplicateCheckService` into `KoogChickenFactsAgent` and register `SaveChickenFactTool` with the dependency (`src/main/kotlin/co/qwex/chickenapi/ai/KoogChickenFactsAgent.kt`).
- Updated `SaveChickenFactTool` to call the duplicate-check service and return a `Result` object containing the candidate `fact`, `sourceUrl`, and `duplicateCheck` metadata instead of only echoing args (`src/main/kotlin/co/qwex/chickenapi/ai/KoogChickenFactsAgent.kt`).
- Reworked the agent strategy `chickenResearchStrategy` to handle duplicate hits: if a `save_chicken_fact` result has `duplicateCheck.hasHit` the strategy feeds duplicate details back to the LLM and retries up to `maxDuplicateRetries`, accepts non-duplicate saves, and logs/fails when retries exceed the cap (`src/main/kotlin/co/qwex/chickenapi/ai/ChickenResearchStrategy.kt`).
- Added focused unit tests `SaveChickenFactToolTests` verifying `SaveChickenFactTool` returns duplicate metadata for a hit and empty matches for a unique fact (`src/test/kotlin/co/qwex/chickenapi/ai/SaveChickenFactToolTests.kt`).

### Testing

- Ran formatting with `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 ./gradlew spotlessApply --no-daemon` which completed successfully.
- Ran the test suite with `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 ./gradlew test --no-daemon` and all tests passed.
- Added unit tests `SaveChickenFactToolTests` which passed as part of the test run.
- Verified the new files and strategy wiring compile and integrate with the agent tooling locally via the above build/test steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c860e810c8321ac74f0f7847bf611)