### PR TITLE
Add Arize Phoenix OTLP tracing for Koog agents (OpenTelemetry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,49 @@ We welcome contributions of all kinds! Here are a few ways you can help:
 
 - First-time production setup guide: `docs/PRODUCTION_FIRST_TIME_SETUP.md`
 
+## Phoenix tracing for AI agents
+
+This project can export Koog agent traces to **Arize Phoenix** over OTLP so you can build evaluations from real runs.
+
+### 1) Run Phoenix locally
+
+```bash
+docker run --rm -it -p 6006:6006 arizephoenix/phoenix:latest
+```
+
+Phoenix UI: `http://localhost:6006`
+
+### 2) Enable tracing in `chicken-api`
+
+Set these environment variables before starting the app:
+
+```bash
+export PHOENIX_COLLECTOR_ENDPOINT=http://localhost:6006/v1/traces
+export KOOG_TRACING_PHOENIX_ENABLED=true
+```
+
+Optional overrides:
+
+- `PHOENIX_PROJECT_NAME` (default: `chicken-api`)
+- `KOOG_TRACING_PHOENIX_SERVICE_NAME` (default: `chicken-api-agents`)
+- `KOOG_TRACING_PHOENIX_SERVICE_VERSION` (default: `0.0.1`)
+- `KOOG_TRACING_PHOENIX_DEPLOYMENT_ENVIRONMENT` (default: current Spring profile)
+
+### 3) Trigger agent runs
+
+Run your normal agent flows (scheduled runs or manual trigger endpoints). Both agents now emit traces:
+
+- `KoogChickenFactsAgent`
+- `KoogBreedResearchAgent`
+
+You should see LLM calls, tool calls, and agent execution spans in Phoenix within a few seconds.
+
+### Why this is standard practice
+
+- **OTLP over HTTP to `/v1/traces`** is Phoenix’s standard collector path for local/self-hosted tracing.
+- **Single shared exporter** is a common OpenTelemetry pattern to avoid repeatedly constructing exporter instances during runtime.
+- **Project grouping** via `x-project-name` and `openinference.project.name` resource attribute is the standard way to keep traces organized for app vs eval workflows.
+
 ## Logging
 
 The application uses [kotlin-logging](https://github.com/MicroUtils/kotlin-logging) with Logback. Log messages include a `requestId` for correlation and are written in plain text locally and JSON in production.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,8 +41,12 @@ configurations.all {
 }
 
 dependencies {
+    implementation(platform("io.opentelemetry:opentelemetry-bom:1.53.0"))
     implementation("ai.koog:koog-agents:0.5.2")
+    implementation("ai.koog:agents-features-opentelemetry:0.5.2")
     implementation("com.squareup.okio:okio:3.9.0")
+    implementation("io.opentelemetry:opentelemetry-exporter-otlp:1.53.0")
+    implementation("io.opentelemetry:opentelemetry-exporter-sender-okhttp:1.53.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:$serializationVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0")

--- a/src/main/kotlin/co/qwex/chickenapi/ai/KoogBreedResearchAgent.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/ai/KoogBreedResearchAgent.kt
@@ -4,6 +4,7 @@ import ai.koog.agents.core.agent.AIAgent
 import ai.koog.agents.core.agent.config.AIAgentConfig
 import ai.koog.agents.core.tools.ToolRegistry
 import ai.koog.agents.features.tracing.feature.Tracing
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
 import ai.koog.agents.features.tracing.writer.TraceFeatureMessageLogWriter
 import ai.koog.prompt.dsl.prompt
 import ai.koog.prompt.executor.llms.SingleLLMPromptExecutor
@@ -17,12 +18,15 @@ import co.qwex.chickenapi.ai.tools.SaveBreedResearchTool
 import co.qwex.chickenapi.ai.tools.WebFetchTool
 import co.qwex.chickenapi.ai.tools.WebSearchTool
 import co.qwex.chickenapi.config.BreedResearchAgentProperties
+import co.qwex.chickenapi.config.PhoenixTracingProperties
 import co.qwex.chickenapi.repository.BreedRepository
 import io.github.oshai.kotlinlogging.KotlinLogging as OshaiKotlinLogging
 import io.ktor.client.HttpClient
 import jakarta.annotation.PostConstruct
 import jakarta.annotation.PreDestroy
 import mu.KotlinLogging
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
@@ -35,6 +39,9 @@ import org.springframework.stereotype.Service
 @Service
 class KoogBreedResearchAgent(
     private val properties: BreedResearchAgentProperties,
+    private val phoenixTracingProperties: PhoenixTracingProperties,
+    private val phoenixSpanExporterProvider: ObjectProvider<OtlpHttpSpanExporter>,
+    private val phoenixResourceAttributesProvider: ObjectProvider<Map<AttributeKey<String>, String>>,
     private val breedRepository: BreedRepository,
     @Qualifier("koogBreedResearchHttpClient")
     private val httpClientProvider: ObjectProvider<HttpClient>,
@@ -147,6 +154,23 @@ class KoogBreedResearchAgent(
                 ) {
                     install(Tracing) {
                         addMessageProcessor(TraceFeatureMessageLogWriter(OshaiKotlinLogging.logger {}))
+                    }
+                    if (phoenixTracingProperties.enabled) {
+                        val phoenixSpanExporter = phoenixSpanExporterProvider.getIfAvailable()
+                        if (phoenixSpanExporter != null) {
+                            val phoenixResourceAttributes = phoenixResourceAttributesProvider.getIfAvailable().orEmpty()
+                            install(OpenTelemetry) {
+                                setServiceInfo(
+                                    phoenixTracingProperties.serviceName,
+                                    phoenixTracingProperties.serviceVersion,
+                                )
+                                addSpanExporter(phoenixSpanExporter)
+                                addResourceAttributes(
+                                    phoenixResourceAttributes +
+                                        mapOf(AttributeKey.stringKey("llm.application") to "breed-research-agent"),
+                                )
+                            }
+                        }
                     }
                 }
             agent.run(BREED_RESEARCH_USER_PROMPT)

--- a/src/main/kotlin/co/qwex/chickenapi/ai/KoogChickenFactsAgent.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/ai/KoogChickenFactsAgent.kt
@@ -27,8 +27,12 @@ import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import ai.koog.agents.features.tracing.feature.Tracing
+import ai.koog.agents.features.opentelemetry.feature.OpenTelemetry
 import ai.koog.agents.features.tracing.writer.TraceFeatureMessageLogWriter
 import io.github.oshai.kotlinlogging.KotlinLogging as OshaiKotlinLogging
+import co.qwex.chickenapi.config.PhoenixTracingProperties
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
 
 /**
  * Wraps a Koog single-run agent that talks to Ollama Cloud and exposes the
@@ -37,6 +41,9 @@ import io.github.oshai.kotlinlogging.KotlinLogging as OshaiKotlinLogging
 @Service
 class KoogChickenFactsAgent(
     private val properties: KoogAgentProperties,
+    private val phoenixTracingProperties: PhoenixTracingProperties,
+    private val phoenixSpanExporterProvider: ObjectProvider<OtlpHttpSpanExporter>,
+    private val phoenixResourceAttributesProvider: ObjectProvider<Map<AttributeKey<String>, String>>,
     private val chickenFactDuplicateCheckService: ChickenFactDuplicateCheckService,
     @Qualifier("koogChickenFactsHttpClient")
     private val httpClientProvider: ObjectProvider<HttpClient>,
@@ -200,6 +207,23 @@ class KoogChickenFactsAgent(
                         //     targetPath = Path("agenttraces/agent-traces-${System.currentTimeMillis()}.log")
                         // ))
                     }
+                    if (phoenixTracingProperties.enabled) {
+                        val phoenixSpanExporter = phoenixSpanExporterProvider.getIfAvailable()
+                        if (phoenixSpanExporter != null) {
+                            val phoenixResourceAttributes = phoenixResourceAttributesProvider.getIfAvailable().orEmpty()
+                            install(OpenTelemetry) {
+                                setServiceInfo(
+                                    phoenixTracingProperties.serviceName,
+                                    phoenixTracingProperties.serviceVersion,
+                                )
+                                addSpanExporter(phoenixSpanExporter)
+                                addResourceAttributes(
+                                    phoenixResourceAttributes +
+                                        mapOf(AttributeKey.stringKey("llm.application") to "chicken-facts-agent"),
+                                )
+                            }
+                        }
+                    }
                 }
             agent.run(properties.prompt)
         } catch (ex: Exception) {
@@ -246,7 +270,7 @@ class SaveChickenFactTool(
     override suspend fun doExecute(args: Args): String {
         log.info { "Saving chicken fact with URL: ${args.sourceUrl}" }
         val duplicateCheck = duplicateCheckService.checkFactForDuplicate(args.fact)
-        return json.encodeToString(
+        return jsonCodec.encodeToString(
             Result.serializer(),
             Result(
                 fact = args.fact,
@@ -257,7 +281,7 @@ class SaveChickenFactTool(
     }
 
     companion object {
-        private val json = Json { prettyPrint = true }
+        private val jsonCodec = Json { prettyPrint = true }
     }
 }
 
@@ -273,7 +297,6 @@ class WebSearchTool(
     private val model: LLModel?,
 ) : SimpleTool<WebSearchTool.Args>() {
     private val log = KotlinLogging.logger {}
-    private val json = Json { ignoreUnknownKeys = true }
 
     @Serializable
     data class Args(
@@ -368,7 +391,7 @@ class WebFetchTool(
     private val model: LLModel?,
 ) : SimpleTool<WebFetchTool.Args>() {
     private val log = KotlinLogging.logger {}
-    private val json = Json { ignoreUnknownKeys = true }
+    private val jsonCodec = Json { ignoreUnknownKeys = true }
 
     @Serializable
     data class Args(
@@ -427,7 +450,7 @@ class WebFetchTool(
         } catch (ex: Exception) {
             log.error(ex) { "Failed to summarize web content from ${args.url}" }
             // Fallback to raw content if summarization fails
-            json.encodeToString(result)
+            jsonCodec.encodeToString(result)
         }
     }
 }

--- a/src/main/kotlin/co/qwex/chickenapi/config/PhoenixTelemetryConfig.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/config/PhoenixTelemetryConfig.kt
@@ -1,0 +1,25 @@
+package co.qwex.chickenapi.config
+
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConditionalOnProperty(prefix = "koog.tracing.phoenix", name = ["enabled"], havingValue = "true")
+class PhoenixTelemetryConfig {
+    @Bean
+    fun phoenixSpanExporter(properties: PhoenixTracingProperties): OtlpHttpSpanExporter =
+        OtlpHttpSpanExporter.builder()
+            .setEndpoint(properties.endpoint)
+            .addHeader("x-project-name", properties.projectName)
+            .build()
+
+    @Bean
+    fun phoenixResourceAttributes(properties: PhoenixTracingProperties): Map<AttributeKey<String>, String> =
+        mapOf(
+            AttributeKey.stringKey("deployment.environment") to properties.deploymentEnvironment,
+            AttributeKey.stringKey("openinference.project.name") to properties.projectName,
+        )
+}

--- a/src/main/kotlin/co/qwex/chickenapi/config/PhoenixTracingProperties.kt
+++ b/src/main/kotlin/co/qwex/chickenapi/config/PhoenixTracingProperties.kt
@@ -1,0 +1,16 @@
+package co.qwex.chickenapi.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+/**
+ * Configuration for exporting Koog agent traces to Arize Phoenix over OTLP.
+ */
+@ConfigurationProperties(prefix = "koog.tracing.phoenix")
+data class PhoenixTracingProperties(
+    val enabled: Boolean = false,
+    val endpoint: String = "http://localhost:6006/v1/traces",
+    val projectName: String = "chicken-api",
+    val serviceName: String = "chicken-api-agents",
+    val serviceVersion: String = "0.0.1",
+    val deploymentEnvironment: String = "local",
+)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -42,3 +42,11 @@ koog.breed-research-agent.model=${koog.agent.model}
 koog.breed-research-agent.web-search-max-results=3
 koog.breed-research-agent.max-agent-iterations=100
 koog.breed-research-agent.max-tool-calls=8
+
+# Phoenix tracing (OTLP HTTP exporter) for Koog agents
+koog.tracing.phoenix.enabled=false
+koog.tracing.phoenix.endpoint=${PHOENIX_COLLECTOR_ENDPOINT:http://localhost:6006/v1/traces}
+koog.tracing.phoenix.project-name=${PHOENIX_PROJECT_NAME:chicken-api}
+koog.tracing.phoenix.service-name=chicken-api-agents
+koog.tracing.phoenix.service-version=0.0.1
+koog.tracing.phoenix.deployment-environment=${SPRING_PROFILES_ACTIVE:local}


### PR DESCRIPTION
### Motivation

- Add optional OpenTelemetry export of Koog agent traces to Arize Phoenix to enable run/eval inspection and grouping of agent traces.

### Description

- Add `PhoenixTracingProperties` and `PhoenixTelemetryConfig` to configure and provide an `OtlpHttpSpanExporter` and resource attributes when `koog.tracing.phoenix.enabled=true`.
- Wire Phoenix tracing into `KoogChickenFactsAgent` and `KoogBreedResearchAgent` to conditionally `install(OpenTelemetry)` with service info, span exporter, and resource attributes when enabled and exporter is available.
- Add OpenTelemetry and Koog opentelemetry feature dependencies and exporters to `build.gradle.kts`, and add default tracing properties to `application.properties`.
- Small refactors in agent tools: rename `Json` instances to `jsonCodec` and remove an unused `json` instance, and update `SaveChickenFactTool` and `WebFetchTool` usages accordingly.
- Update `README.md` with local Phoenix run instructions and step-by-step enablement notes for OTLP export with example environment variables.

### Testing

- Built the project with `./gradlew build` which completed successfully.
- Ran the test suite with `./gradlew test` which ran and passed in CI-local verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0898cff36c832182a2b7766e1fea8b)